### PR TITLE
Add Metropolis beamer theme to installation requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Installing and running
     *   [pandoc filter](https://github.com/jgm/pandocfilters)
     *   [TeX Live](http://www.tug.org/texlive/) including the
         [beamer class](https://www.ctan.org/pkg/beamer)
+    *   [beamer theme: Metropolis](https://github.com/matze/mtheme) (for building the examples)
 
 2.  Create a working directory for your project and change into it.
 


### PR DESCRIPTION
The beamer package of my distribution does not provide `beamerthememetropolis.sty`, so I had to install it manually.