### PR TITLE
Images: Rework handling of images (slides, web)

### DIFF
--- a/filters/hugo.lua
+++ b/filters/hugo.lua
@@ -35,27 +35,12 @@ function Math(el)
 end
 
 
--- Nest an image in a Div to center it and allow manual scaling
---
--- This is essentially the construct that Hugo would create for
--- shortcode `{{% figure src="path" title="text" width="60%" %}}`
--- Now we can just write `![text](path){width="60%}` instead ...
+-- Emit custom shortcode `img`: `{{% img src="path" title="text" width="60%" %}}`
 function Image(el)
-    local width  = el.attributes["width"]  or "auto"
-    local height = el.attributes["height"] or "auto"
-    local style  = string.format("width:%s;height:%s;", width, height)
-    local alt    = pandoc.utils.stringify(el.caption)
+    local w = el.attributes["width"] or "auto"
+    local t = pandoc.utils.stringify(el.caption)
 
-    return {
-            pandoc.RawInline('markdown', '<div class="center" style="' .. style .. '">'),
-            pandoc.RawInline('markdown', '<figure>'),
-            pandoc.RawInline('markdown', '<img src="' .. el.src .. '" alt="' .. alt ..'">'),
-            pandoc.RawInline('markdown', '<figcaption><h4>'),
-            pandoc.Str(alt),
-            pandoc.RawInline('markdown', '</h4></figcaption>'),
-            pandoc.RawInline('markdown', '</figure>'),
-            pandoc.RawInline('markdown', '</div>')
-           }
+    return pandoc.RawInline('markdown', '{{% img src="' .. el.src .. '" title="' .. t .. '" width="' .. w .. '" %}}')
 end
 
 

--- a/filters/hugo.lua
+++ b/filters/hugo.lua
@@ -35,9 +35,16 @@ function Math(el)
 end
 
 
--- Emit custom shortcode `img`: `{{% img src="path" title="text" width="60%" %}}`
+-- Emit custom shortcode `img`:
+-- Convert `![text](path){width=60%}` into `{{% img src="path" title="text" width="60%" %}}`
+--
+-- Scaling of images with the custom shortcode `img` currently works only in terms of image width.
+-- By default, the `width` parameter from the Pandoc link attribute will be used, which is then
+-- identical for both the slides and the web version. To achieve a different scaling for just the
+-- web version, you can use the `web_width` parameter, which takes precedence over the normal `width`
+-- parameter.
 function Image(el)
-    local w = el.attributes["width"] or "auto"
+    local w = el.attributes["web_width"] or el.attributes["width"] or "auto"
     local t = pandoc.utils.stringify(el.caption)
 
     return pandoc.RawInline('markdown', '{{% img src="' .. el.src .. '" title="' .. t .. '" width="' .. w .. '" %}}')

--- a/filters/tex.lua
+++ b/filters/tex.lua
@@ -27,7 +27,12 @@ end
 
 
 -- center images without captions too (like "real" images w/ caption)
+--
+-- remove as a precaution a possibly existing parameter `web_width`, which
+-- should only be respected in the web version.
 function Image(el)
+    el.attributes["web_width"] = nil
+
     if el.caption and #el.caption == 0 then
         return { pandoc.RawInline('latex', '\\begin{center}'), el, pandoc.RawInline('latex', '\\end{center}') }
     end


### PR DESCRIPTION
- Web: Emit custom shortcode `img`
- Web: Use parameter `web_width` with higher precedence as `width`
- Slides: Remove parameter `web_width` if present

see https://github.com/PM-Dungeon/PM-Lecture/issues/129