### PR TITLE
[HUGO] Re-Learn-Theme 5.x: emit original 'button' shortcode instead of custom shortcode

### DIFF
--- a/filters/hugo.lua
+++ b/filters/hugo.lua
@@ -72,10 +72,13 @@ end
 function Span(el)
     -- Replace "bsp" Span with "button" Shortcode
     if el.classes[1] == "bsp" then
-        return
-            { pandoc.RawInline("markdown", "{{% button-crossreference %}}") } ..
-            el.content ..
-            { pandoc.RawInline("markdown", "{{% /button-crossreference %}}") }
+        return {
+            pandoc.RawInline('markdown', '<div style="text-align: right;">'),
+            pandoc.RawInline('markdown', '{{% button style="btn-crossreference" %}}')
+        } .. el.content .. {
+            pandoc.RawInline('markdown', '{{% /button %}}'),
+            pandoc.RawInline('markdown', '</div>')
+        }
     end
 
     -- Transform all other native Spans to "real" Spans digestible to Hugo


### PR DESCRIPTION
The "button" shortcode in Hugo-Re-Learn-Theme seems to be improved in 5.x, so let's use the original button (again). Thus the "hugo.lua" filter will emit code using the original shortcode.