### PR TITLE
[HUGO] emit 'math' shortcode instead of span/div

### DIFF
--- a/filters/hugo.lua
+++ b/filters/hugo.lua
@@ -20,16 +20,16 @@ end
 function Math(el)
     if el.mathtype:match 'InlineMath' then
         return {
-            pandoc.RawInline('markdown', '<span>'),
+            pandoc.RawInline('markdown', '{{< math >}}'),
             el,
-            pandoc.RawInline('markdown', '</span>')
+            pandoc.RawInline('markdown', '{{< /math >}}')
           }
     end
     if el.mathtype:match 'DisplayMath' then
         return {
-            pandoc.RawInline('markdown', '<div>'),
+            pandoc.RawInline('markdown', '{{< math >}}'),
             el,
-            pandoc.RawInline('markdown', '</div>')
+            pandoc.RawInline('markdown', '{{< /math >}}')
           }
     end
 end


### PR DESCRIPTION
Hugo Re-Learn-Theme 5.x supports MathJax natively. Inline and block math should
be encapsulated in a provided 'math' shortcode.