### PR TITLE
Hugo: Add key/value parameter "href" to shortcode "button"

### DIFF
--- a/filters/hugo.lua
+++ b/filters/hugo.lua
@@ -71,7 +71,7 @@ end
 -- Replace native Spans with "real" Spans or Shortcodes
 function Span(el)
     -- Replace "bsp" span with "button" shortcode
-    -- Use key "href" as href parameter in shortcode
+    -- Use key/value pair "href=..." as href parameter in shortcode
     if el.classes[1] == "bsp" then
         return {
             pandoc.RawInline('markdown', '<div style="text-align: right;">'),

--- a/filters/hugo.lua
+++ b/filters/hugo.lua
@@ -75,7 +75,7 @@ function Span(el)
     if el.classes[1] == "bsp" then
         return {
             pandoc.RawInline('markdown', '<div style="text-align: right;">'),
-            pandoc.RawInline('markdown', '{{% button style="btn-crossreference" href="' .. el.attributes["href"] or "" .. '" %}}')
+            pandoc.RawInline('markdown', '{{% button style="btn-crossreference" href="' .. (el.attributes["href"] or "") .. '" %}}')
         } .. el.content .. {
             pandoc.RawInline('markdown', '{{% /button %}}'),
             pandoc.RawInline('markdown', '</div>')

--- a/filters/hugo.lua
+++ b/filters/hugo.lua
@@ -70,11 +70,12 @@ end
 
 -- Replace native Spans with "real" Spans or Shortcodes
 function Span(el)
-    -- Replace "bsp" Span with "button" Shortcode
+    -- Replace "bsp" span with "button" shortcode
+    -- Use key "href" as href parameter in shortcode
     if el.classes[1] == "bsp" then
         return {
             pandoc.RawInline('markdown', '<div style="text-align: right;">'),
-            pandoc.RawInline('markdown', '{{% button style="btn-crossreference" %}}')
+            pandoc.RawInline('markdown', '{{% button style="btn-crossreference" href="' .. el.attributes["href"] .. '" %}}')
         } .. el.content .. {
             pandoc.RawInline('markdown', '{{% /button %}}'),
             pandoc.RawInline('markdown', '</div>')

--- a/filters/hugo.lua
+++ b/filters/hugo.lua
@@ -71,7 +71,7 @@ end
 -- Replace native Spans with "real" Spans or Shortcodes
 function Span(el)
     -- Replace "bsp" span with "button" shortcode
-    -- Use key/value pair "href=..." as href parameter in shortcode
+    -- Use key/value pair "href=..." in span as href parameter in shortcode
     if el.classes[1] == "bsp" then
         return {
             pandoc.RawInline('markdown', '<div style="text-align: right;">'),

--- a/filters/hugo.lua
+++ b/filters/hugo.lua
@@ -75,7 +75,7 @@ function Span(el)
     if el.classes[1] == "bsp" then
         return {
             pandoc.RawInline('markdown', '<div style="text-align: right;">'),
-            pandoc.RawInline('markdown', '{{% button style="btn-crossreference" href="' .. el.attributes["href"] .. '" %}}')
+            pandoc.RawInline('markdown', '{{% button style="btn-crossreference" href="' .. el.attributes["href"] or "" .. '" %}}')
         } .. el.content .. {
             pandoc.RawInline('markdown', '{{% /button %}}'),
             pandoc.RawInline('markdown', '</div>')


### PR DESCRIPTION
Enables a key/value parameter `href` in span `bsp`. 

Examples: 

- Old behaviour (still valid): `[Get Hugo]{.bsp}` 
- New behaviour: `[Get Hugo]{.bsp href="https://gohugo.io/"}`

Lua filter: 

- TeX: `tex.lua`: `\bsp{Get Hugo}` (both cases)
- Hugo: `hugo.lua`:
    - Old behaviour: `<div style="text-align: right;">{{% button style="btn-crossreference" href="" %}}Get Hugo{{% /button %}}</div>` 
    - New behaviour: `<div style="text-align: right;">{{% button style="btn-crossreference" href="https://gohugo.io/" %}}Get Hugo{{% /button %}}</div>`

see also https://github.com/Programmiermethoden/PM-Lecture/issues/620