### PR TITLE
[Hugo] Fix image handling 

### DIFF
--- a/defaults/hugo.yaml
+++ b/defaults/hugo.yaml
@@ -1,6 +1,6 @@
 ## Lecture options (Hugo pre-processing)
 
-from: markdown-smart+lists_without_preceding_blankline
+from: markdown+lists_without_preceding_blankline-smart-implicit_figures
 to: markdown+smart-grid_tables-multiline_tables-simple_tables
 
 strip-comments: true

--- a/defaults/slides.yaml
+++ b/defaults/slides.yaml
@@ -1,6 +1,6 @@
 ## Lecture options (slides)
 
-from: markdown+rebase_relative_paths+lists_without_preceding_blankline
+from: markdown+lists_without_preceding_blankline+rebase_relative_paths
 to: beamer
 
 metadata-file: metadata.yaml

--- a/filters/hugo.lua
+++ b/filters/hugo.lua
@@ -40,6 +40,7 @@ end
 -- Images (empty title): Convert scaling from Pandoc markdown to Hugo Relearn theme
 --        "![](img/wuppie.png){width=20%}" will become "![](img/wuppie.png?width=20%25)"
 -- Figures (non-empty title): Emit custom shortcode `img`
+--        "![Wuppieee](img/wuppie.png){width=20%}" will become "{{% img src="img/wuppie.png?width=20%25" caption="Wuppieee" width="20%" height="auto" class="center" %}}"
 --
 -- If both the "width" and "web_width" parameters are present, "web_width" takes precedence
 -- over the regular "width" parameter. Likewise for "height" and "web_height".

--- a/filters/hugo.lua
+++ b/filters/hugo.lua
@@ -52,10 +52,10 @@ function Image(el)
     local t = pandoc.utils.stringify(el.caption)
 
     if t == "" then
-        -- Empty caption "image": Just transform width/height for Hugo and Relearn theme
+        -- Empty caption ("image"): Just transform width/height for Hugo and Relearn theme
         return pandoc.Image("", el.src .. "?width=" .. w:gsub("%%", "%%25") .. "&height=" .. h:gsub("%%", "%%25"))
     else
-        -- Non-empty caption "figure": Emit `img` shortcode for Hugo
+        -- Non-empty caption ("figure"): Emit `img` shortcode for Hugo
         -- (custom shortcode, see https://github.com/cagix/pandoc-lecture/pull/28)
         return pandoc.RawInline('markdown', '{{% img src="' .. el.src .. '" caption="' .. t .. '" width="' .. w .. '" height="' .. h .. '" class="center" %}}')
     end

--- a/filters/hugo.lua
+++ b/filters/hugo.lua
@@ -35,19 +35,29 @@ function Math(el)
 end
 
 
--- Emit custom shortcode `img`:
--- Convert `![text](path){width=60%}` into `{{% img src="path" title="text" width="60%" %}}`
+-- Handling of images for Hugo
 --
--- Scaling of images with the custom shortcode `img` currently works only in terms of image width.
--- By default, the `width` parameter from the Pandoc link attribute will be used, which is then
--- identical for both the slides and the web version. To achieve a different scaling for just the
--- web version, you can use the `web_width` parameter, which takes precedence over the normal `width`
--- parameter.
+-- Images (empty title): Convert scaling from Pandoc markdown to Hugo Relearn theme
+--        "![](img/wuppie.png){width=20%}" will become "![](img/wuppie.png?width=20%25)"
+-- Figures (non-empty title): Emit custom shortcode `img`
+--
+-- If both the "width" and "web_width" parameters are present, "web_width" takes precedence
+-- over the regular "width" parameter. Likewise for "height" and "web_height".
+--
+-- This needs "-implicit_figures" for Pandoc (see https://github.com/cagix/pandoc-lecture/pull/28).
 function Image(el)
-    local w = el.attributes["web_width"] or el.attributes["width"] or "auto"
+    local w = el.attributes["web_width"]  or el.attributes["width"]  or "auto"
+    local h = el.attributes["web_height"] or el.attributes["height"] or "auto"
     local t = pandoc.utils.stringify(el.caption)
 
-    return pandoc.RawInline('markdown', '{{% img src="' .. el.src .. '" title="' .. t .. '" width="' .. w .. '" %}}')
+    if t == "" then
+        -- Empty caption "image": Just transform width/height for Hugo and Relearn theme
+        return pandoc.Image("", el.src .. "?width=" .. w:gsub("%%", "%%25") .. "&height=" .. h:gsub("%%", "%%25"))
+    else
+        -- Non-empty caption "figure": Emit `img` shortcode for Hugo
+        -- (custom shortcode, see https://github.com/cagix/pandoc-lecture/pull/28)
+        return pandoc.RawInline('markdown', '{{% img src="' .. el.src .. '" caption="' .. t .. '" width="' .. w .. '" height="' .. h .. '" class="center" %}}')
+    end
 end
 
 

--- a/filters/tex.lua
+++ b/filters/tex.lua
@@ -26,16 +26,15 @@ function Div(el)
 end
 
 
--- center images without captions too (like "real" images w/ caption)
+-- center images without captions too (like "real" images w/ caption aka figures)
 --
 -- remove as a precaution a possibly existing parameter `web_width`, which
 -- should only be respected in the web version.
+--
+-- note: images w/ caption will be parsed (implicitly) as figures instead - no need to check for empty caption here
 function Image(el)
     el.attributes["web_width"] = nil
-
-    if el.caption and #el.caption == 0 then
-        return { pandoc.RawInline('latex', '\\begin{center}'), el, pandoc.RawInline('latex', '\\end{center}') }
-    end
+    return { pandoc.RawInline('latex', '\\begin{center}'), el, pandoc.RawInline('latex', '\\end{center}') }
 end
 
 

--- a/hugo/hugo-lecture/layouts/shortcodes/img.html
+++ b/hugo/hugo-lecture/layouts/shortcodes/img.html
@@ -1,7 +1,8 @@
-{{ $src   := .Get "src"   | default "" }}
-{{ $title := .Get "title" | default "" }}
-{{ $class := .Get "class" | default "" }}
-{{ $width := .Get "width" | default "auto"}}
+{{ $src     := .Get "src"     | default "" }}
+{{ $caption := .Get "caption" | default "" }}
+{{ $width   := .Get "width"   | default "auto"}}
+{{ $height  := .Get "height"  | default "auto"}}
+{{ $class   := .Get "class"   | default "" }}
 
 {{ $src = urls.Parse $src }}
 {{ if $src.Scheme }}
@@ -33,14 +34,11 @@
 {{ end }}
 
 {{/*
-    Setting the width of the figure is just a workaround: It should be possible to set the
-    width/height of an image using a style for the img tag. However, Hugo (or some of our
-    configuration) seems to gobble this somehow and adds a 'style="width: auto; height: auto;"',
-    which is not quite helpful.
+    Emulating the native Hugo shortcode "{{% figure src="..." caption="..." width="..." height="..." class="..." %}}"
 */}}
 {{ with $src }}
-<figure class="center" style="width:{{- $width -}}">
-    <img alt="{{- $title -}}" src="{{- $src | safeURL -}}" class="{{- $class -}}" />
-    {{ with $title }}<figcaption><h4>{{- $title -}}</h4></figcaption>{{ end }}
+<figure class="{{- $class -}}">
+    <img src="{{- $src | safeURL -}}" alt="{{- $caption -}}" width="{{- $width -}}" height="{{- $height -}}">
+    <figcaption><p>{{- $caption | markdownify -}}</p></figcaption>
 </figure>
 {{ end }}


### PR DESCRIPTION
## Beschreibung

In Pandoc-Markdown gibt es zwei Typen von Abbildungen: "Images" (ohne Caption) und "Figures" (mit Caption). Für das Anpassen der Größe können in Pandoc-Markdown Attribute verwendet werden. (https://pandoc.org/MANUAL.html#images)

Das Hugo Relearn Theme unterstützt eigentlich nur "Images", d.h. Abbildungen mit Caption sind nicht vorgesehen. Die Skalierung erfolgt über einen URL-Parameter. Abbildungen werden mit einer "Lightbox" dargestellt - hier kann man auf die Abbildung draufklicken und erhält dann die Abbildung in Vollansicht. (https://mcshelby.github.io/hugo-theme-relearn/cont/markdown/index.html#images) 

Prinzipiell unterstützt Hugo (und das Relearn Theme) Mehrsprachigkeit. Bei Abbildungen werden diese allerdings nur im Pfad der Default-Sprache abgelegt, für die Sprachvarianten müssen die Abbildungspfade entsprechend angepasst werden. Das funktioniert im Relearn-Theme automatisch für "Images", nicht aber für den durch Hugo bereitgestellten `figure`-Shortcode.

## Aufgaben

- [x] Skalierung für "Images" muss umgerechnet werden: Aus `![](images/wuppie.png){width=20%}` muss `![](images/wuppie.png?width=20%25)` werden. Das kann im Pandoc-Filter `hugo.lua` gemacht werden.
- [x] Für "Figures" muss eine vernünftige Lösung gefunden werden.

## Lösungsansätze

Drei Optionen beim Umgang mit "Figures" bei der Generierung von HTML:

*   Option 1: Ignorieren

        -implicit_figures
        Filter liefert Image mit angepasstem Pfad

        => Images als Image mit Pfad
        => Figures als Image mit Pfad

        Figure:
        + Skalierung
        + Relearn Lightbox
        - Caption

*   Option 2: Pandoc

        +implicit_figures
        Filter liefert Image mit angepasstem Pfad

        => Images als Image mit Pfad
        => Figures als HTML-Figures (durch Pandoc)

        Figure:
        - Skalierung
        - Relearn Lightbox
        + Caption

*   **Option 3**: Hugo

        -implicit_figures
        Filter liefert Image mit angepasstem Pfad bzw. `image`-/`img`-Shortcode für Figures [^1]

        Figure:
        => Images als Image mit Pfad
        => Figures als `image`-/`img`-Shortcode (für Hugo)

        + Skalierung
        - Relearn Lightbox
        + Caption

        [^1]: Image: Titel == "", Figure: Titel != ""
        Durch "-implicit_figures" laufen alle Bilder in die Funktion "Image(el)" und werden
        dort gemeinsam verarbeitet. 
        Wenn man "+implicit_figures" aktiviert lassen würde, dann würden Figures getrennt 
        von den Images in die Funktion "Figure(el)" laufen. Allerdings enthält ein 
        pandoc.Figure neben der Caption auch (verschachtelt) ein pandoc.Image, und dieses  
        würde dann durch die Funktion "Image(el)" zusätzlich modifiziert - dadurch fehlen 
        entweder die Attribute für das verschachtelte Image oder (wenn man diese in 
        "Image(el)" wieder mit gibt) die Attribute tauchen auch an den Images auf und Hugo 
        gibt diese nach dem Image aus.

Beispiele (Option 3): 

```
Images
![](images/fahrplan.png){width="40%"}                                           ![](images/fahrplan.png?width=40%25&height=auto)

Figures
![Das wird eine Figure](images/fahrplan.png){width="40%" web_width="80%"}       {{% figure src="images/fahrplan.png" caption="Das wird eine Figure" width="80%" height="auto" class="center" %}}
```

## Umsetzung

Option 3 zeigt die meisten Vorteile - die Abbildungen werden skaliert und bekommen eine Caption, lediglich die Lightbox fehlt. Vermutlich ist dies für die wenigen Fälle, wo tatsächlich eine Figure statt einem Image genutzt wird, besser als eine Skalierung + Lightbox zu haben, aber keine Caption?

Der von Hugo angebotene Shortcode `image` kann aber die Pfadauflösung für Multi-Lang-Support irgendwie nicht. Deshalb wird der Weg über Pandoc und einen eigenen Shortcode eingeschlagen:
- Pandoc-Option `-implicit_figures`, damit alle Abbildungen als Image betrachtet werden (`hugo.yaml`)
- Lua-Filter mit `Image(el)`-Funktion (`hugo.lua`)
    - rechnet die Skalierung um für Images (leerer Titel)
    - gibt einen `img`-Shortcode aus für Figures (Titel nicht leer)
- Shortcode `img.html`
    - rechnet für die Figures den Pfad passend aus (betrifft eigentlich nur Multi-Lang-Support)
    - emuliert das Verhalten des nativen `image`-Shortcodes von Hugo

Zusätzlich wird die TeX-Variante etwas aufgeräumt: Gleiche die Reihenfolge der Markdown-Optionen in `slides.yaml` an die in `hugo.yaml` an und entferne die überflüssige Prüfung auf einen leeren Titel-String für Images in `tex.lua` (Pandoc parst Abbildungen nur dann als "Images", wenn der Titel-String leer ist - sonst werden es "Figures"). Bei der TeX-Variante sollen "Figures" aber weiterhin als solche gerendert werden, d.h. hier wird `-implicit_figures` _nicht_ eingeführt.

---

fixes https://github.com/Programmiermethoden/PM-Lecture/issues/621
