### PR TITLE
[Partials] Quizzes: Use shortcodes/notice.html from Relearne theme

### DIFF
--- a/hugo/hugo-lecture/layouts/partials/quizzes.html
+++ b/hugo/hugo-lecture/layouts/partials/quizzes.html
@@ -14,6 +14,7 @@
     {{ partial "shortcodes/notice.html" (dict
         "context" .
         "style" "tip"
+        "icon" "fas fa-user-check"
         "title" "Quizzes"
         "content" $c
     )}}

--- a/hugo/hugo-lecture/layouts/partials/quizzes.html
+++ b/hugo/hugo-lecture/layouts/partials/quizzes.html
@@ -12,11 +12,11 @@
     {{ $c = printf "%s%s" $c "</ul>" }}
 
     {{ partial "shortcodes/notice.html" (dict
-        "context" .
-        "style" "tip"
-        "title" "Quizzes"
-        "icon" "fas fa-user-check"
-        "content" $c
+    "context" .
+    "style" "tip"
+    "title" "Quizzes"
+    "icon" "fas fa-user-check"
+    "content" $c
     )}}
 
 {{ end }}

--- a/hugo/hugo-lecture/layouts/partials/quizzes.html
+++ b/hugo/hugo-lecture/layouts/partials/quizzes.html
@@ -1,21 +1,21 @@
 {{ $quizzes := .Params.quizzes }}
 {{ if $quizzes }}
 
-{{ $c := "<ul>" }}
-{{ range $quizzes }}
-    {{ $name := index . "name" }}
-    {{ $link := index . "link" }}
-    {{ if $link }}
-    {{ $c = printf "%s <li><a href='%s' class='icon reading' target='_blank' rel='nofollow noopener noreferrer'>%s</a></li>" $c ($link | safeURL) (default $link $name) }}
+    {{ $c := "<ul>" }}
+    {{ range $quizzes }}
+        {{ $name := index . "name" }}
+        {{ $link := index . "link" }}
+        {{ if $link }}
+            {{ $c = $c | printf "%s <li><a href='%s' class='icon reading' target='_blank' rel='nofollow noopener noreferrer'>%s</a></li>" . ($link | safeURL) (default $link $name) }}
+        {{ end }}
     {{ end }}
-{{ end }}
-{{ $c = printf "%s%s" $c "</ul>" }}
+    {{ $c = printf "%s%s" $c "</ul>" }}
 
-{{ partial "shortcodes/notice.html" (dict
-"context" .
-"style" "tip"
-"title" "Quizzes"
-"content" $c
-)}}
+    {{ partial "shortcodes/notice.html" (dict
+        "context" .
+        "style" "tip"
+        "title" "Quizzes"
+        "content" $c
+    )}}
 
 {{ end }}

--- a/hugo/hugo-lecture/layouts/partials/quizzes.html
+++ b/hugo/hugo-lecture/layouts/partials/quizzes.html
@@ -1,21 +1,21 @@
 {{ $quizzes := .Params.quizzes }}
 {{ if $quizzes }}
 
-{{ $c := "<ul>" }}
-{{ range $quizzes }}
-    {{ $name := index . "name" }}
-    {{ $link := index . "link" }}
-    {{ if $link }}
-        {{ $c = printf "%s <li><a href='%s' class='icon reading' target='_blank' rel='nofollow noopener noreferrer'>%s</a></li>" $c ($link | safeURL) (default $link $name) }}
+    {{ $c := "<ul>" }}
+    {{ range $quizzes }}
+        {{ $name := index . "name" }}
+        {{ $link := index . "link" }}
+        {{ if $link }}
+            {{ $c = printf "%s <li><a href='%s' class='icon reading' target='_blank' rel='nofollow noopener noreferrer'>%s</a></li>" $c ($link | safeURL) (default $link $name) }}
+        {{ end }}
     {{ end }}
-{{ end }}
-{{ $c = printf "%s%s" $c "</ul>" }}
+    {{ $c = printf "%s%s" $c "</ul>" }}
 
-{{ partial "shortcodes/notice.html" (dict
-"context" .
-"style" "tip"
-"title" "Quizzes"
-"content" $c
-)}}
+    {{ partial "shortcodes/notice.html" (dict
+        "context" .
+        "style" "tip"
+        "title" "Quizzes"
+        "content" $c
+    )}}
 
 {{ end }}

--- a/hugo/hugo-lecture/layouts/partials/quizzes.html
+++ b/hugo/hugo-lecture/layouts/partials/quizzes.html
@@ -6,7 +6,7 @@
     {{ $name := index . "name" }}
     {{ $link := index . "link" }}
     {{ if $link }}
-        {{ $c = printf "%s <li><a href=\"%s\" class=\"icon reading\" target=\"_blank\" rel=\"nofollow noopener noreferrer\"><strong>%s</strong></a></li>" $c ($link | safeURL) (default $link $name) }}
+    {{ $c = printf "%s <li><a href='%s' class='icon reading' target='_blank' rel='nofollow noopener noreferrer'><strong%s</strong%s</a></li>" $c ($link | safeURL) (default $link $name) }}
     {{ end }}
 {{ end }}
 {{ $c = printf "%s%s" $c "</ul>" }}

--- a/hugo/hugo-lecture/layouts/partials/quizzes.html
+++ b/hugo/hugo-lecture/layouts/partials/quizzes.html
@@ -15,6 +15,7 @@
         "context" .
         "style" "tip"
         "title" "Quizzes"
+        "icon" "fas fa-user-check"
         "content" $c
     )}}
 

--- a/hugo/hugo-lecture/layouts/partials/quizzes.html
+++ b/hugo/hugo-lecture/layouts/partials/quizzes.html
@@ -15,7 +15,6 @@
 "context" .
 "style" "tip"
 "title" "Quizzes"
-"icon" "fas fa-user-check"
 "content" $c
 )}}
 

--- a/hugo/hugo-lecture/layouts/partials/quizzes.html
+++ b/hugo/hugo-lecture/layouts/partials/quizzes.html
@@ -1,22 +1,22 @@
 {{ $quizzes := .Params.quizzes }}
 {{ if $quizzes }}
 
-    {{ $c := "<ul>" }}
-    {{ range $quizzes }}
-        {{ $name := index . "name" }}
-        {{ $link := index . "link" }}
-        {{ if $link }}
-            {{ $c = $c | printf "%s <li><a href='%s' class='icon reading' target='_blank' rel='nofollow noopener noreferrer'>%s</a></li>" . ($link | safeURL) (default $link $name) }}
-        {{ end }}
+{{ $c := "<ul>" }}
+{{ range $quizzes }}
+    {{ $name := index . "name" }}
+    {{ $link := index . "link" }}
+    {{ if $link }}
+        {{ $c = $c | printf "%s <li><a href='%s' class='icon reading' target='_blank' rel='nofollow noopener noreferrer'>%s</a></li>" . ($link | safeURL) (default $link $name) }}
     {{ end }}
-    {{ $c = printf "%s%s" $c "</ul>" }}
+{{ end }}
+{{ $c = printf "%s%s" $c "</ul>" }}
 
-    {{ partial "shortcodes/notice.html" (dict
+{{ partial "shortcodes/notice.html" (dict
     "context" .
     "style" "tip"
     "title" "Quizzes"
     "icon" "fas fa-user-check"
     "content" $c
-    )}}
+)}}
 
 {{ end }}

--- a/hugo/hugo-lecture/layouts/partials/quizzes.html
+++ b/hugo/hugo-lecture/layouts/partials/quizzes.html
@@ -1,15 +1,15 @@
 {{ $quizzes := .Params.quizzes }}
 {{ if $quizzes }}
 
-$c := "<ul>"
+{{ $c := "<ul>" }}
 {{ range $quizzes }}
     {{ $name := index . "name" }}
     {{ $link := index . "link" }}
     {{ if $link }}
-        $c = printf "%s%s" $c "<li><a href=\"" + ($link | safeURL) + "\" class=\"icon reading\" target=\"_blank\" rel=\"nofollow noopener noreferrer\"><strong>" + (default $link $name) + "</strong></a></li>"
+        {{ $c = printf "%s%s" $c "<li><a href=\"" + ($link | safeURL) + "\" class=\"icon reading\" target=\"_blank\" rel=\"nofollow noopener noreferrer\"><strong>" + (default $link $name) + "</strong></a></li>" }}
     {{ end }}
 {{ end }}
-$c = printf "%s%s" $c "</ul>"
+{{ $c = printf "%s%s" $c "</ul>" }}
 
 {{ partial "shortcodes/notice.html" (dict
 "context" .

--- a/hugo/hugo-lecture/layouts/partials/quizzes.html
+++ b/hugo/hugo-lecture/layouts/partials/quizzes.html
@@ -6,7 +6,7 @@
     {{ $name := index . "name" }}
     {{ $link := index . "link" }}
     {{ if $link }}
-        {{ $c = printf "%s%s" $c "<li><a href=\"" + ($link | safeURL) + "\" class=\"icon reading\" target=\"_blank\" rel=\"nofollow noopener noreferrer\"><strong>" + (default $link $name) + "</strong></a></li>" }}
+        {{ $c = printf "%s <li><a href=\"%s\" class=\"icon reading\" target=\"_blank\" rel=\"nofollow noopener noreferrer\"><strong>%s</strong></a></li>" $c ($link | safeURL) (default $link $name) }}
     {{ end }}
 {{ end }}
 {{ $c = printf "%s%s" $c "</ul>" }}

--- a/hugo/hugo-lecture/layouts/partials/quizzes.html
+++ b/hugo/hugo-lecture/layouts/partials/quizzes.html
@@ -6,7 +6,7 @@
     {{ $name := index . "name" }}
     {{ $link := index . "link" }}
     {{ if $link }}
-    {{ $c = printf "%s <li><a href='%s' class='icon reading' target='_blank' rel='nofollow noopener noreferrer'><strong%s</strong%s</a></li>" $c ($link | safeURL) (default $link $name) }}
+    {{ $c = printf "%s <li><a href='%s' class='icon reading' target='_blank' rel='nofollow noopener noreferrer'>%s</a></li>" $c ($link | safeURL) (default $link $name) }}
     {{ end }}
 {{ end }}
 {{ $c = printf "%s%s" $c "</ul>" }}

--- a/hugo/hugo-lecture/layouts/partials/quizzes.html
+++ b/hugo/hugo-lecture/layouts/partials/quizzes.html
@@ -1,20 +1,21 @@
 {{ $quizzes := .Params.quizzes }}
-
 {{ if $quizzes }}
-<div class="quizzes">
-    <h2>Quizzes</h2>
 
-    <ul>
-    {{ range $quizzes }}
-        {{ $name := index . "name" }}
-        {{ $link := index . "link" }}
-        {{ if $link }}
-        <li>
-            <a href="{{- $link | safeURL -}}" class="icon reading" target="_blank" rel="nofollow noopener noreferrer"><strong>{{- default $link $name -}}</strong></a>
-        </li>
-        {{ end }}
+$c := "<ul>"
+{{ range $quizzes }}
+    {{ $name := index . "name" }}
+    {{ $link := index . "link" }}
+    {{ if $link }}
+        $c = printf "%s%s" $c "<li><a href=\"" + ($link | safeURL) + "\" class=\"icon reading\" target=\"_blank\" rel=\"nofollow noopener noreferrer\"><strong>" + (default $link $name) + "</strong></a></li>"
     {{ end }}
-    </ul>
+{{ end }}
+$c = printf "%s%s" $c "</ul>"
 
-</div>
+{{ partial "shortcodes/notice.html" (dict
+"context" .
+"style" "tip"
+"title" "Quizzes"
+"content" $c
+)}}
+
 {{ end }}

--- a/hugo/hugo-lecture/layouts/partials/quizzes.html
+++ b/hugo/hugo-lecture/layouts/partials/quizzes.html
@@ -12,11 +12,11 @@
 {{ $c = printf "%s%s" $c "</ul>" }}
 
 {{ partial "shortcodes/notice.html" (dict
-    "context" .
-    "style" "tip"
-    "title" "Quizzes"
-    "icon" "fas fa-user-check"
-    "content" $c
+"context" .
+"style" "tip"
+"title" "Quizzes"
+"icon" "fas fa-user-check"
+"content" $c
 )}}
 
 {{ end }}

--- a/hugo/hugo-lecture/layouts/partials/quizzes.html
+++ b/hugo/hugo-lecture/layouts/partials/quizzes.html
@@ -6,7 +6,7 @@
     {{ $name := index . "name" }}
     {{ $link := index . "link" }}
     {{ if $link }}
-        {{ $c = $c | printf "%s <li><a href='%s' class='icon reading' target='_blank' rel='nofollow noopener noreferrer'>%s</a></li>" . ($link | safeURL) (default $link $name) }}
+        {{ $c = printf "%s <li><a href='%s' class='icon reading' target='_blank' rel='nofollow noopener noreferrer'>%s</a></li>" $c ($link | safeURL) (default $link $name) }}
     {{ end }}
 {{ end }}
 {{ $c = printf "%s%s" $c "</ul>" }}


### PR DESCRIPTION
Statt eigener Lösung setze das Partial [`shortcodes/notice.html`](https://github.com/McShelby/hugo-theme-relearn/blob/main/layouts/partials/shortcodes/notice.html) vom [Relearne theme](https://github.com/McShelby/hugo-theme-relearn/tree/main) ein. 

Vorteile:
- Weniger Code-Duplizierung durch Nutzung bestehender Strukturen
- Bessere Unterstützung des Dark Mode

see https://github.com/Programmiermethoden/PM-Lecture/issues/614