### PR TITLE
[Partials] Assignments: Use shortcodes/notice.html from Relearne theme

### DIFF
--- a/hugo/hugo-lecture/layouts/partials/assignments.html
+++ b/hugo/hugo-lecture/layouts/partials/assignments.html
@@ -5,12 +5,9 @@
     {{ $schedule = $data.schedule }}
 {{ end }}
 
-
 {{ if $assignments }}
-<div class="assignments">
-    <h2>Übungsblätter/Aufgaben</h2>
 
-    <ul>
+    {{ $c := "<ul>" }}
     {{ range $assignments }}
         {{ $topic := index . "topic" }}
         {{ $due := "" }}
@@ -23,13 +20,19 @@
         {{ end }}
 
         {{ with $.Site.GetPage $topic }}
-            <li>
-                <a href="{{- .Permalink | safeURL -}}"><strong>{{- .Title -}}</strong></a>
-                {{ with $due }}{{ printf " (Abgabe: %s)" . }}{{ end }}
-            </li>
+            {{ $c = printf "%s <li><a href='%s' class='icon reading' target='_blank' rel='nofollow noopener noreferrer'>%s</a>" $c (.Permalink | safeURL) .Title }}
+            {{ with $due }}{{ $c = printf "%s (Abgabe: %s)" $c . }}{{ end }}
+            {{ $c = printf "%s</li>" $c }}
         {{ end }}
     {{ end }}
-    </ul>
+    {{ $c = printf "%s</ul>" $c }}
 
-</div>
+    {{ partial "shortcodes/notice.html" (dict
+        "context" .
+        "style" "note"
+        "icon" "fas fa-laptop-code"
+        "title" "Übungsblätter/Aufgaben"
+        "content" $c
+    )}}
+
 {{ end }}

--- a/hugo/hugo-lecture/layouts/partials/outcomes.html
+++ b/hugo/hugo-lecture/layouts/partials/outcomes.html
@@ -1,4 +1,5 @@
 {{ $outcomes := .Params.outcomes }}
+
 {{ if (and $outcomes (reflect.IsSlice $outcomes)) }}    {{/* do not engage unless it's a list: workaround for use in lecture-cy */}}
 
     {{ $c := "<ul>" }}
@@ -8,7 +9,7 @@
         {{ with index . "k3" }}{{ $c = printf "%s <li>(K3) %s</li>" $c (. | markdownify) }}{{ end }}
         {{ with index . "k4" }}{{ $c = printf "%s <li>(K4) %s</li>" $c (. | markdownify) }}{{ end }}
     {{ end }}
-    {{ $c = printf "%s%s" $c "</ul>" }}
+    {{ $c = printf "%s</ul>" $c }}
 
     {{ partial "shortcodes/notice.html" (dict
         "context" .

--- a/hugo/hugo-lecture/layouts/partials/quizzes.html
+++ b/hugo/hugo-lecture/layouts/partials/quizzes.html
@@ -1,4 +1,5 @@
 {{ $quizzes := .Params.quizzes }}
+
 {{ if $quizzes }}
 
     {{ $c := "<ul>" }}
@@ -9,7 +10,7 @@
             {{ $c = printf "%s <li><a href='%s' class='icon reading' target='_blank' rel='nofollow noopener noreferrer'>%s</a></li>" $c ($link | safeURL) (default $link $name) }}
         {{ end }}
     {{ end }}
-    {{ $c = printf "%s%s" $c "</ul>" }}
+    {{ $c = printf "%s</ul>" $c }}
 
     {{ partial "shortcodes/notice.html" (dict
         "context" .


### PR DESCRIPTION
Statt eigener Lösung setze das Partial [`shortcodes/notice.html`](https://github.com/McShelby/hugo-theme-relearn/blob/main/layouts/partials/shortcodes/notice.html) vom [Relearne theme](https://github.com/McShelby/hugo-theme-relearn/tree/main) ein. 

Vorteile:
- Weniger Code-Duplizierung durch Nutzung bestehender Strukturen
- Bessere Unterstützung des Dark Mode

see https://github.com/Programmiermethoden/PM-Lecture/issues/614