### PR TITLE
[Partials] Challenges: Use shortcodes/notice.html from Relearne theme

### DIFF
--- a/hugo/hugo-lecture/layouts/partials/archetypes/lecture-cg/article.html
+++ b/hugo/hugo-lecture/layouts/partials/archetypes/lecture-cg/article.html
@@ -12,6 +12,7 @@
     {{ partial "outcomes.html" . }}
     {{ $content | safeHTML }}
     {{ partial "quizzes.html" . }}
+    {{ partial "challenges.html" . }}
     {{ partial "assignments.html" . }}
     {{ partial "bib.html" . }}
 {{ end }}

--- a/hugo/hugo-lecture/layouts/partials/challenges.html
+++ b/hugo/hugo-lecture/layouts/partials/challenges.html
@@ -1,0 +1,15 @@
+{{ $challenges := .Params.challenges }}
+
+{{ if $challenges }}
+
+    {{ $c := $challenges | markdownify }}
+
+    {{ partial "shortcodes/notice.html" (dict
+        "context" .
+        "style" "note"
+        "icon" "fas fa-puzzle-piece"
+        "title" "Challenges"
+        "content" $c
+    )}}
+
+{{ end }}


### PR DESCRIPTION
Wiedereinführung von Challenges und Aktivierung im `lecture-cg`-Archetypen.

Statt eigener Lösung setze das Partial [`shortcodes/notice.html`](https://github.com/McShelby/hugo-theme-relearn/blob/main/layouts/partials/shortcodes/notice.html) vom [Relearne theme](https://github.com/McShelby/hugo-theme-relearn/tree/main) ein. 

Vorteile:
- Weniger Code-Duplizierung durch Nutzung bestehender Strukturen
- Bessere Unterstützung des Dark Mode

see https://github.com/Programmiermethoden/PM-Lecture/issues/614