### PR TITLE
[Partials] TLDR: Use shortcodes/notice.html from Relearne theme

### DIFF
--- a/hugo/hugo-lecture/layouts/partials/archetypes/lecture-bc/article.html
+++ b/hugo/hugo-lecture/layouts/partials/archetypes/lecture-bc/article.html
@@ -8,6 +8,9 @@
 {{ if .Params.sketch }}
     {{ partial "sketch.html" . }}
 {{ else }}
+    {{ .Scratch.Set "attachments_title" "Annotierte Folien" }}
+    {{ partial "attachments.html" . }}
+
     {{ $content | safeHTML }}
 
     {{ partial "bib.html" . }}

--- a/hugo/hugo-lecture/layouts/partials/archetypes/lecture-bc/article.html
+++ b/hugo/hugo-lecture/layouts/partials/archetypes/lecture-bc/article.html
@@ -9,10 +9,10 @@
     {{ partial "sketch.html" . }}
 {{ else }}
     {{ $content | safeHTML }}
+
     {{ partial "bib.html" . }}
     {{ partial "outcomes.html" . }}
     {{ partial "assignments.html" . }}
-    {{ partial "quizzes.html" . }}
 {{ end }}
 
 

--- a/hugo/hugo-lecture/layouts/partials/archetypes/lecture-bc/article.html
+++ b/hugo/hugo-lecture/layouts/partials/archetypes/lecture-bc/article.html
@@ -8,7 +8,6 @@
 {{ if .Params.sketch }}
     {{ partial "sketch.html" . }}
 {{ else }}
-    {{ partial "tldr.html" . }}
     {{ $content | safeHTML }}
     {{ partial "bib.html" . }}
     {{ partial "outcomes.html" . }}

--- a/hugo/hugo-lecture/layouts/partials/archetypes/lecture-cg/article.html
+++ b/hugo/hugo-lecture/layouts/partials/archetypes/lecture-cg/article.html
@@ -9,8 +9,21 @@
     {{ partial "sketch.html" . }}
 {{ else }}
     {{ partial "tldr.html" . }}
+
+    {{ .Scratch.Set "videos_params" .Params.youtube }}
+    {{ .Scratch.Set "videos_title" "Videos (YouTube)" }}
+    {{ .Scratch.Set "videos_linktext" "Direkt-Link YouTube" }}
+    {{ partial "videos.html" . }}
+
+    {{ .Scratch.Set "videos_params" .Params.fhmedia }}
+    {{ .Scratch.Set "videos_title" "Videos (FH-Medienportal)" }}
+    {{ .Scratch.Set "videos_linktext" "Direkt-Link FH-Medienportal" }}
+    {{ partial "videos.html" . }}
+
     {{ partial "outcomes.html" . }}
+
     {{ $content | safeHTML }}
+
     {{ partial "quizzes.html" . }}
     {{ partial "challenges.html" . }}
     {{ partial "assignments.html" . }}

--- a/hugo/hugo-lecture/layouts/partials/archetypes/lecture-cg/article.html
+++ b/hugo/hugo-lecture/layouts/partials/archetypes/lecture-cg/article.html
@@ -20,6 +20,9 @@
     {{ .Scratch.Set "videos_linktext" "Direkt-Link FH-Medienportal" }}
     {{ partial "videos.html" . }}
 
+    {{ .Scratch.Set "attachments_title" "Slides" }}
+    {{ partial "attachments.html" . }}
+
     {{ partial "outcomes.html" . }}
 
     {{ $content | safeHTML }}

--- a/hugo/hugo-lecture/layouts/partials/archetypes/lecture-cy/article.html
+++ b/hugo/hugo-lecture/layouts/partials/archetypes/lecture-cy/article.html
@@ -13,8 +13,7 @@
     {{ .Scratch.Set "videos_linktext" "Direkt-Link YouTube" }}
     {{ partial "videos.html" . }}
 
-    {{ .Scratch.Set "attachments_header" "Folien" }}
-    {{ .Scratch.Set "attachments_level" 2 }}
+    {{ .Scratch.Set "attachments_title" "Folien" }}
     {{ partial "attachments.html" . }}
 
     <div class="recap">

--- a/hugo/hugo-lecture/layouts/partials/archetypes/lecture-cy/article.html
+++ b/hugo/hugo-lecture/layouts/partials/archetypes/lecture-cy/article.html
@@ -8,12 +8,10 @@
 {{ if .Params.sketch }}
     {{ partial "sketch.html" . }}
 {{ else }}
-    {{ if .Params.youtube }}
-        <h2>Videos</h2>
-        {{ .Scratch.Set "params" .Params.youtube }}
-        {{ .Scratch.Set "linktext" "Direkt-Link YouTube" }}
-        {{ partial "videos.html" . }}
-    {{ end }}
+    {{ .Scratch.Set "videos_params" .Params.youtube }}
+    {{ .Scratch.Set "videos_title" "Videos" }}
+    {{ .Scratch.Set "videos_linktext" "Direkt-Link YouTube" }}
+    {{ partial "videos.html" . }}
 
     {{ .Scratch.Set "attachments_header" "Folien" }}
     {{ .Scratch.Set "attachments_level" 2 }}

--- a/hugo/hugo-lecture/layouts/partials/attachments.html
+++ b/hugo/hugo-lecture/layouts/partials/attachments.html
@@ -1,14 +1,9 @@
 {{ $attachments := .Params.attachments }}
-
-{{ $header := .Scratch.Get "attachments_header" | default "Materialien" }}
-{{ $level  := .Scratch.Get "attachments_level"  | default 2 }}
-
+{{ $title       := .Scratch.Get "attachments_title" | default "Materialien" }}
 
 {{ if $attachments }}
-<div class="attachments">
-    <h{{- $level -}}>{{- $header -}}</h{{- $level -}}>
 
-    <ul>
+    {{ $c := "<ul>" }}
     {{ range $attachments }}
         {{ $n := index . "name" | default "(annotierter) Foliensatz" }}
         {{ with index . "link" }}
@@ -40,10 +35,17 @@
                     {{ $url = replace $url $current_lang $default_lang }}
                 {{ end }}
             {{ end }}
-            <li><a href="{{- $url | safeURL -}}" target="_blank" rel="nofollow noopener noreferrer">{{- $n -}}</a></li>
+            {{ $c = printf "%s <li><a href='%s' class='icon reading' target='_blank' rel='nofollow noopener noreferrer'>%s</a></li>" $c ($url | safeURL) $n }}
         {{ end }}
     {{ end }}
-    </ul>
+    {{ $c = printf "%s</ul>" $c }}
 
-</div>
+    {{ partial "shortcodes/notice.html" (dict
+        "context" .
+        "style" "info"
+        "icon" "far fa-file-powerpoint"
+        "title" $title
+        "content" $c
+    )}}
+
 {{ end }}

--- a/hugo/hugo-lecture/layouts/partials/tldr.html
+++ b/hugo/hugo-lecture/layouts/partials/tldr.html
@@ -1,35 +1,15 @@
 {{ $tldr := .Params.tldr }}
-{{ $yt := .Params.youtube }}
-{{ $fh := .Params.fhmedia }}
-{{ $attachments := .Params.attachments }}
 
-{{ if (or $tldr (or $attachments (or $yt $fh))) }}
-<div class="tldr">
-    <h2>TL;DR</h2>
+{{ if $tldr }}
 
-    {{ with $tldr }}
-        {{ . | $.RenderString }}
-    {{ end }}
+    {{ $c := $tldr | markdownify }}
 
-    {{ if $yt }}
-        <h3>Videos (YouTube)</h3>
-        {{ .Scratch.Set "params" $yt }}
-        {{ .Scratch.Set "linktext" "Direkt-Link YouTube" }}
-        {{ partial "videos.html" . }}
-    {{ end }}
+    {{ partial "shortcodes/notice.html" (dict
+        "context" .
+        "style" "info"
+        "icon" "fas fa-graduation-cap"
+        "title" "TL;DR"
+        "content" $c
+    )}}
 
-    {{ if $fh }}
-        <h3>Videos (FH-Medienportal)</h3>
-        {{ .Scratch.Set "params" $fh }}
-        {{ .Scratch.Set "linktext" "Direkt-Link FH-Medienportal" }}
-        {{ partial "videos.html" . }}
-    {{ end }}
-
-    {{ if $attachments }}
-        {{ .Scratch.Set "attachments_header" "(Annotierte) Folien" }}
-        {{ .Scratch.Set "attachments_level" 3 }}
-        {{ partial "attachments.html" . }}
-    {{ end }}
-
-</div>
 {{ end }}

--- a/hugo/hugo-lecture/layouts/partials/videos.html
+++ b/hugo/hugo-lecture/layouts/partials/videos.html
@@ -1,12 +1,24 @@
-{{ $params   := .Scratch.Get "params" }}
-{{ $linktext := .Scratch.Get "linktext" }}
+{{ $videos   := .Scratch.Get "videos_params" }}
+{{ $title    := .Scratch.Get "videos_title" | default "Videos" }}
+{{ $linktext := .Scratch.Get "videos_linktext" | default "Direkt-Link" }}
 
-<ul>
-{{ range $params }}
-    {{ $n := index . "name" | default $linktext }}
+{{ if $videos }}
 
-    {{ with index . "link" }}
-        <li><a href="{{- . | safeURL -}}" target="_blank" rel="nofollow noopener noreferrer">{{- $n -}}</a></li>
+    {{ $c := "<ul>" }}
+    {{ range $videos }}
+        {{ $n := index . "name" | default $linktext }}
+        {{ with index . "link" }}
+            {{ $c = printf "%s <li><a href='%s' class='icon reading' target='_blank' rel='nofollow noopener noreferrer'>%s</a></li>" $c (. | safeURL) $n }}
+        {{ end }}
     {{ end }}
+    {{ $c = printf "%s</ul>" $c }}
+
+    {{ partial "shortcodes/notice.html" (dict
+        "context" .
+        "style" "info"
+        "icon" "fas fa-podcast"
+        "title" $title
+        "content" $c
+    )}}
+
 {{ end }}
-</ul>


### PR DESCRIPTION
Splitte TLDR auf in "TLDR", "Videos", "Attachments": Das reduziert komplexere Abfragen durch mind. drei verschiedene Anwendungsfälle und erlaubt zusätzlich den Einsatz unterschiedlicher Notice-Boxen/-Farben/-Icons.

Statt eigener Lösung setze das Partial [`shortcodes/notice.html`](https://github.com/McShelby/hugo-theme-relearn/blob/main/layouts/partials/shortcodes/notice.html) vom [Relearne theme](https://github.com/McShelby/hugo-theme-relearn/tree/main) ein. 

Vorteile:
- Weniger Code-Duplizierung durch Nutzung bestehender Strukturen
- Bessere Unterstützung des Dark Mode


fixes https://github.com/Programmiermethoden/PM-Lecture/issues/614