### PR TITLE
Update URL to digibib.net

### DIFF
--- a/filters/fhbib.lua
+++ b/filters/fhbib.lua
@@ -5,7 +5,8 @@
 -- reference to ISBN 12345 would be linked to https://worldcat.org/isbn/12345
 -- my students would rather like to know availability in university library,
 -- thus change generated URL to https://www.digibib.net/openurl/Bi10?isbn=12345
+-- 03/2023: the URL apparently changed to https://fhb-bielefeld.digibib.net/openurl?isbn=12345 (?)
 function Link(el)
-    el.target = el.target:gsub("^https://worldcat.org/isbn/(%d[0-9%-]+%d)$", "https://www.digibib.net/openurl/Bi10?isbn=%1")
+    el.target = el.target:gsub("^https://worldcat.org/isbn/(%d[0-9%-]+%d)$", "https://fhb-bielefeld.digibib.net/openurl?isbn=%1")
     return el
 end

--- a/hugo/hugo-lecture/layouts/partials/bib.html
+++ b/hugo/hugo-lecture/layouts/partials/bib.html
@@ -38,7 +38,7 @@
             {{ if $details }}
                 {{ $c = printf "%s<br>%s." $c $details }}
                 {{ if $isbn }}
-                    {{ $c = printf "%s ISBN <a href='https://www.digibib.net/openurl/Bi10?isbn=%s' class='icon reading' target='_blank' rel='nofollow noopener noreferrer'>%s</a>." $c ($isbn | safeURL) $isbn }}
+                    {{ $c = printf "%s ISBN <a href='https://fhb-bielefeld.digibib.net/openurl?isbn=%s' class='icon reading' target='_blank' rel='nofollow noopener noreferrer'>%s</a>." $c ($isbn | safeURL) $isbn }}
                 {{ end }}
                 {{ if $doi }}
                     {{ $c = printf "%s DOI <a href='https://doi.org/%s' class='icon reading' target='_blank' rel='nofollow noopener noreferrer'>%s</a>." $c ($doi | safeURL) $doi }}


### PR DESCRIPTION
Statt `https://www.digibib.net/openurl/Bi10?isbn=978-1-6172-9199-9` ist es jetzt offenbar `https://fhb-bielefeld.digibib.net/openurl?isbn=978-1-6172-9199-9`. 

fixes https://github.com/Programmiermethoden/PM-Lecture/issues/622