### PR TITLE
Hugo: Remove hardcoded license from menu footer

### DIFF
--- a/hugo/hugo-lecture/layouts/partials/menu-footer.html
+++ b/hugo/hugo-lecture/layouts/partials/menu-footer.html
@@ -1,5 +1,3 @@
 <p style="text-align: center; padding: 2rem 1rem;">
 {{ readFile "static/links.html" | safeHTML }}
-<br />
-<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons Licence" style="border-width:0;margin:0;display:inline;" src="https://i.creativecommons.org/l/by-sa/4.0/80x15.png" /></a>
 </p>


### PR DESCRIPTION
Initially, it seemed like a good idea to hard wire the CC BY-SA 4.0 directly in the menu footer.

But since pandoc-lecture is now also used for other projects, each project has to define this for itself.