### PR TITLE
hugo.lua: remove custom background for showme/expand

### DIFF
--- a/filters/hugo.lua
+++ b/filters/hugo.lua
@@ -67,9 +67,9 @@ function Div(el)
     -- Replace "showme" Div with "expand" Shortcode
     if el.classes[1] == "showme" then
         return
-            { pandoc.RawBlock("markdown", '{{% expand "Show Me" %}}'), pandoc.RawBlock("markdown", "<div class='showme'>") } ..
+            { pandoc.RawBlock("markdown", '{{% expand "Show Me" %}}') } ..
             el.content ..
-            { pandoc.RawBlock("markdown", "</div>"), pandoc.RawBlock("markdown", "{{% /expand %}}") }
+            { pandoc.RawBlock("markdown", "{{% /expand %}}") }
     end
 
     -- Transform all other native Divs to "real" Divs digestible to Hugo


### PR DESCRIPTION
Initially we used some custom css styling (background, text color) for the `showme` div, which is replaced by the `expand` shortcode.

However, this does not work well in dark mode. This PR removes the custom styling for the `showme` div / `expand` shortcode.