### PR TITLE
hugo.lua: replace `cbox` div with centered `button` shortcode

### DIFF
--- a/filters/hugo.lua
+++ b/filters/hugo.lua
@@ -72,12 +72,12 @@ function Div(el)
             { pandoc.RawBlock("markdown", "{{% /expand %}}") }
     end
 
-    -- Replace "cbox" Div with "notice" Shortcode
+    -- Replace "cbox" Div with centered "button" Shortcode
     if el.classes[1] == "cbox" then
         return
-            { pandoc.RawBlock("markdown", '{{% notice style="info" %}}') } ..
+            { pandoc.RawBlock("markdown", '<div style="text-align:center;">'), pandoc.RawBlock("markdown", '{{% button style="primary" %}}') } ..
             el.content ..
-            { pandoc.RawBlock("markdown", "{{% /notice %}}") }
+            { pandoc.RawBlock("markdown", "{{% /button %}}"), pandoc.RawBlock("markdown", "</div>") }
     end
 
     -- Transform all other native Divs to "real" Divs digestible to Hugo


### PR DESCRIPTION
Using a `notice` shortcode for the previous `cbox` div/environment seemed like a good idea. However, a `notice` always goes across the entire width of the page, which is somewhat annoying. Furthermore, only the heading is highlighted with a strong colour, the actual box is rather discreet. The `button`, on the other hand, is only as wide as the text, and it uses the eye-catching colour for the entire box.

This PR replaces the "cbox"-div/environment with a centered `button` shortcode.