### PR TITLE
[Clean-Up] Remove extra words in due date and points (schedule shortcode, assignments archetype)

### DIFF
--- a/hugo/hugo-lecture/layouts/partials/archetypes/assignment/article.html
+++ b/hugo/hugo-lecture/layouts/partials/archetypes/assignment/article.html
@@ -28,11 +28,11 @@
     {{ partial "sketch.html" . }}
 {{ else }}
     {{ if and $points $due}}
-        <p><strong>{{- printf "(Punkte: %d, Abgabe: %s)" $points $due -}}</strong></p>
+        <p><strong>{{- printf "(Punkte: %d; %s)" $points $due -}}</strong></p>
     {{ else if $points }}
         <p><strong>{{- printf "(Punkte: %d)" $points -}}</strong></p>
     {{ else if $due }}
-        <p><strong>{{- printf "(Abgabe: %s)" $due -}}</strong></p>
+        <p><strong>{{- printf "(%s)" $due -}}</strong></p>
     {{ else }}
     {{ end }}
 

--- a/hugo/hugo-lecture/layouts/partials/archetypes/assignment/article.html
+++ b/hugo/hugo-lecture/layouts/partials/archetypes/assignment/article.html
@@ -28,9 +28,9 @@
     {{ partial "sketch.html" . }}
 {{ else }}
     {{ if and $points $due}}
-        <p><strong>{{- printf "(Punkte: %d; %s)" $points $due -}}</strong></p>
+        <p><strong>{{- printf "(%s; %s)" $points $due -}}</strong></p>
     {{ else if $points }}
-        <p><strong>{{- printf "(Punkte: %d)" $points -}}</strong></p>
+        <p><strong>{{- printf "(%s)" $points -}}</strong></p>
     {{ else if $due }}
         <p><strong>{{- printf "(%s)" $due -}}</strong></p>
     {{ else }}

--- a/hugo/hugo-lecture/layouts/shortcodes/schedule.html
+++ b/hugo/hugo-lecture/layouts/shortcodes/schedule.html
@@ -69,7 +69,7 @@
                     <li>
                         {{ $title := .Params.menutitle | default .Title }}
                         <a href="{{- .Permalink | safeURL -}}"><strong>{{- $title -}}</strong></a>
-                        {{ if $due }}<br>{{ printf "(Abgabe: %s)" $due }}{{ end }}
+                        {{ if $due }}<br>{{ printf "(%s)" $due }}{{ end }}
                     </li>
                     {{ end }}
                 {{ end }}


### PR DESCRIPTION
Ursprünglich war es ganz nett, die Worte "Punkte: " und "Abgabe: " automatisch aus dem YAML bzw. dem Schedule ableiten zu können und nicht immer extra hinschreiben zu müssen. Durch verschiedene Lehrveranstaltungen sind nun aber unterschiedliche Bedürfnisse entstanden, so dass dies aus dem Shortcode und dem Archetype entfernt wird.

Man muss also jetzt im `data/schedule.yaml` jetzt schreiben:

```yaml
-   week: "W12 (23. Juni)"
    assignment:
        -   topic: "b05b"
            due: "Abgabe: Do, 22.06."
```

und in den Aufgabenblättern im YAML-Header:

```yaml
points: "15 Punkte"
```

---

Bisher: 

`data/schedule.yaml`:

```yaml
-   week: "W12 (23. Juni)"
    assignment:
        -   topic: "b05b"
            due: "Do, 22.06."
```

Aufgabenblätter im YAML-Header:

```yaml
points: "15"
```