### PR TITLE
[Filter] add filter to convert metadata title to (first) H1 header

### DIFF
--- a/filters/title2h1.lua
+++ b/filters/title2h1.lua
@@ -1,0 +1,7 @@
+-- Convert metadata title to (first) H1 header in document
+
+function Pandoc(doc)
+    if doc.meta.title then
+        return pandoc.Pandoc({ pandoc.Header(1, doc.meta.title) } .. doc.blocks, doc.meta)
+    end
+end


### PR DESCRIPTION
Background: We use the title field in the YAML header, and in the document the headings start with H2 headers. This automatically sets the title correctly on the title page for Beamer slides, also when converting with Hugo this becomes the heading for the page. However, to create documents (Book) with LaTeX, we need a proper heading instead. 

This filter converts the metadata field "title" into a H1 heading and inserts it at the beginning of the document.
