### PR TITLE
Makefile: add install target to allow for easier local installation of pandoc-lecture and relearn theme (scripts only)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,15 @@ arm64:
 	cd docker && make arm64
 
 
+## Install Pandoc-Lecture and Hugo Relearn Theme to ${HOME}/.local/share/pandoc/ for local use
+.PHONY: install_scripts_locally
+install_scripts_locally:
+	mkdir -p ${HOME}/.local/share/
+	export XDG_DATA_HOME="${HOME}/.local/share/"   && \
+	sh docker/install-pandoc-lecture.sh            && \
+	sh docker/install-relearn.sh
+
+
 ## Demo
 .PHONY: demo-lecture
 demo-lecture:


### PR DESCRIPTION
Just in case. We usually use this via a GitHub action or locally in a Docker container. But if someone insists on using this locally (without Docker) and already has Pandoc, Hugo and TexLive installed locally, they can use the new target `install_scripts_locally` to easily install the scripts in Pandoc-Lecture and Relearn Hugo to `${HOME}/.local/share/pandoc/`.
