### PR TITLE
[Docker] remove package "software-properties-common"

### DIFF
--- a/docker/install-packages-ubuntu.sh
+++ b/docker/install-packages-ubuntu.sh
@@ -2,5 +2,5 @@
 
 ## Ubuntu: base packages
 apt-get update
-apt-get install -y software-properties-common ca-certificates build-essential bash git make gzip tar wget
+apt-get install -y ca-certificates build-essential bash git make gzip tar wget
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
package "software-properties-common" is not really needed ...

to fix possible certificate errors when running wget on https urls we just need the package "ca-certificates". 

"software-properties-common" includes "ca-certificates", but also python and several other packages not needed here.