### PR TITLE
[Docker] remove package "build-essential"

### DIFF
--- a/docker/install-packages-ubuntu.sh
+++ b/docker/install-packages-ubuntu.sh
@@ -2,5 +2,5 @@
 
 ## Ubuntu: base packages
 apt-get update
-apt-get install -y ca-certificates build-essential bash git make gzip tar wget
+apt-get install -y ca-certificates bash git make gzip tar wget
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
package "build-essential" is not really needed. it contains "make", but also gcc and several other packages not needed here.