### PR TITLE
[Docker] add package "graphviz"

### DIFF
--- a/docker/install-packages-ubuntu.sh
+++ b/docker/install-packages-ubuntu.sh
@@ -2,5 +2,5 @@
 
 ## Ubuntu: base packages
 apt-get update
-apt-get install -y ca-certificates bash git make gzip tar wget
+apt-get install -y ca-certificates bash git make gzip tar wget graphviz
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
package "graphviz" is used to convert .dot files to .png or .svg during the compilation of the lecture material.

you can argue whether the creation of the .png files from the .dot sources really has to happen during the build process or whether you should just commit the .png files associated with a .dot file directly to the repo when creating the .dot file ...