### PR TITLE
[Action] remove installing additional Ubuntu packages (graphviz)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,10 +22,6 @@ runs:
         mkdir -p $HOME/.local/share/
       shell: bash
 
-    - name: 'Install additional Ubuntu packages'
-      run: sudo sh ${{ github.action_path }}/docker/install-packages-ubuntu.sh
-      shell: bash
-
     - name: 'Download Pandoc'
       run: sh ${{ github.action_path }}/docker/download-pandoc.sh
       shell: bash


### PR DESCRIPTION
wow, just installing **graphiz** inside the ubuntu runner will increase the **setup time** for the base of this action **_from 2s to 25s_**! since this was already open for discussion, removing this step from the action for the time being ...