### PR TITLE
[Action] use "apt-get clean"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,7 @@ runs:
       run: |
         echo "XDG_DATA_HOME=$HOME/.local/share" >> $GITHUB_ENV
         echo "ARCH=amd64" >> $GITHUB_ENV
+        echo "DEBIAN_FRONTEND=noninteractive" >> $GITHUB_ENV
         mkdir -p $HOME/.local/share/
       shell: bash
 

--- a/docker/install-packages-ubuntu.sh
+++ b/docker/install-packages-ubuntu.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 ## Ubuntu: base packages
-apt-get update
+apt-get clean && apt-get update
 apt-get install -y ca-certificates bash git make gzip tar wget graphviz ghostscript
 rm -rf /var/lib/apt/lists/*

--- a/docker/install-texlive-extra.sh
+++ b/docker/install-texlive-extra.sh
@@ -5,6 +5,6 @@
 ## see https://github.com/Wandmalfarbe/pandoc-latex-template#texlive
 
 ## TexLive (extra packages)
-apt-get update
+apt-get clean && apt-get update
 apt-get install -y texlive-fonts-extra texlive-science
 rm -rf /var/lib/apt/lists/*

--- a/docker/install-texlive.sh
+++ b/docker/install-texlive.sh
@@ -5,6 +5,6 @@
 ## see https://github.com/Wandmalfarbe/pandoc-latex-template#texlive
 
 ## TexLive
-apt-get update
+apt-get clean && apt-get update
 apt-get install -y texlive texlive-latex-extra texlive-lang-german lmodern cm-super
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
use `apt-get clean && apt-get update` instead of `apt-get update` to avoid errors while fetching packages from server

(see also https://serverfault.com/questions/690639/api-get-error-reading-from-server-under-docker)