### PR TITLE
Pandoc/Hugo: Merge download script into install scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Local use without Docker is also an option for Unix-like operating systems like 
 
 -   [Pandoc](https://github.com/cagix/pandoc-lecture/blob/master/docker/download-pandoc.sh) and [Pandoc-Lecture](https://github.com/cagix/pandoc-lecture/blob/master/docker/install-pandoc-lecture.sh)
 -   For the web page:
-    -   [Hugo](https://github.com/cagix/pandoc-lecture/blob/master/docker/download-hugo.sh)
+    -   [Hugo](https://github.com/cagix/pandoc-lecture/blob/master/docker/install-hugo.sh)
     -   [Hugo Relearn-Theme](https://github.com/cagix/pandoc-lecture/blob/master/docker/install-relearn.sh)
 -   For the PDF slide sets:
     -   [TeX-Live](https://github.com/cagix/pandoc-lecture/blob/master/docker/install-texlive.sh)

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ With `make runlocal`, issued in your local shell, the container will be launched
 
 Local use without Docker is also an option for Unix-like operating systems like Linux or macOS (_but is not recommended_). For this purpose, the specified tools have to be installed manually using the correct versions. The files linked below provide both the download URLs for the respective binaries and the required version numbers:
 
--   [Pandoc](https://github.com/cagix/pandoc-lecture/blob/master/docker/download-pandoc.sh) and [Pandoc-Lecture](https://github.com/cagix/pandoc-lecture/blob/master/docker/install-pandoc-lecture.sh)
+-   [Pandoc](https://github.com/cagix/pandoc-lecture/blob/master/docker/install-pandoc.sh) and [Pandoc-Lecture](https://github.com/cagix/pandoc-lecture/blob/master/docker/install-pandoc-lecture.sh)
 -   For the web page:
     -   [Hugo](https://github.com/cagix/pandoc-lecture/blob/master/docker/install-hugo.sh)
     -   [Hugo Relearn-Theme](https://github.com/cagix/pandoc-lecture/blob/master/docker/install-relearn.sh)

--- a/action.yaml
+++ b/action.yaml
@@ -44,11 +44,6 @@ runs:
       shell: bash
 
     ## Plus: Install Hugo (if requested)
-    - name: 'Download Hugo'
-      run: sh ${{ github.action_path }}/docker/download-hugo.sh
-      shell: bash
-      if: ${{ inputs.hugo == 'true' }}
-
     - name: 'Install Hugo'
       run: sudo sh ${{ github.action_path }}/docker/install-hugo.sh
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -27,10 +27,6 @@ runs:
         mkdir -p $HOME/.local/share/
       shell: bash
 
-    - name: 'Download Pandoc'
-      run: sh ${{ github.action_path }}/docker/download-pandoc.sh
-      shell: bash
-
     - name: 'Install Pandoc'
       run: sudo sh ${{ github.action_path }}/docker/install-pandoc.sh
       shell: bash

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,9 +28,6 @@ RUN /root/install-pandoc-lecture.sh  &&  rm -rf /root/install-pandoc-lecture.sh
 
 
 ## Install Hugo and Hugo Relearn Theme
-COPY download-hugo.sh  /root/download-hugo.sh
-RUN /root/download-hugo.sh  &&  rm -rf /root/download-hugo.sh
-
 COPY install-hugo.sh  /root/install-hugo.sh
 RUN /root/install-hugo.sh  &&  rm -rf /root/install-hugo.sh
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,9 +17,6 @@ RUN /root/install-packages-ubuntu.sh  &&  rm -rf /root/install-packages-ubuntu.s
 
 
 ## Install Pandoc and Pandoc-Lecture
-COPY download-pandoc.sh  /root/download-pandoc.sh
-RUN /root/download-pandoc.sh  &&  rm -rf /root/download-pandoc.sh
-
 COPY install-pandoc.sh  /root/install-pandoc.sh
 RUN /root/install-pandoc.sh  &&  rm -rf /root/install-pandoc.sh
 

--- a/docker/download-hugo.sh
+++ b/docker/download-hugo.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-## Versions
-export HUGO="0.115.3"
-# set ARCH="amd64" or ARCH="arm64" externally
-
-## Hugo: https://github.com/gohugoio/hugo/releases/latest/
-## split into two steps: Download + Install to enable reuse in Docker and GitHub actions
-wget https://github.com/gohugoio/hugo/releases/download/v${HUGO}/hugo_${HUGO}_linux-${ARCH}.tar.gz

--- a/docker/download-pandoc.sh
+++ b/docker/download-pandoc.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-## Versions
-export PANDOC="3.1.5"
-# set ARCH="amd64" or ARCH="arm64" externally
-
-## Pandoc: https://github.com/jgm/pandoc/releases/latest/
-## split into two steps: Download + Install to enable reuse in Docker and GitHub actions
-wget https://github.com/jgm/pandoc/releases/download/${PANDOC}/pandoc-${PANDOC}-linux-${ARCH}.tar.gz

--- a/docker/install-hugo.sh
+++ b/docker/install-hugo.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
-## split into two steps: Download + Install to enable reuse in Docker and GitHub actions
+## Versions
+export HUGO="0.115.3"
+# set ARCH="amd64" or ARCH="arm64" externally
+
+## Hugo: https://github.com/gohugoio/hugo/releases/latest/
+wget https://github.com/gohugoio/hugo/releases/download/v${HUGO}/hugo_${HUGO}_linux-${ARCH}.tar.gz
+
 tar -zxf hugo_*.tar.gz -C /usr/local/bin/
 rm hugo_*.tar.gz

--- a/docker/install-pandoc.sh
+++ b/docker/install-pandoc.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
-## split into two steps: Download + Install to enable reuse in Docker and GitHub actions
+## Versions
+export PANDOC="3.1.5"
+# set ARCH="amd64" or ARCH="arm64" externally
+
+## Pandoc: https://github.com/jgm/pandoc/releases/latest/
+wget https://github.com/jgm/pandoc/releases/download/${PANDOC}/pandoc-${PANDOC}-linux-${ARCH}.tar.gz
+
 tar -zxf pandoc-*.tar.gz --strip-components 1 -C /usr/local/
 rm pandoc-*.tar.gz


### PR DESCRIPTION
For some reason lost in history, the download and install for both Pandoc and Hugo were split into two separate steps. Since I can't seem to summon enough imagination for this schism, this PR merges the download script with the install script for both tools.