### PR TITLE
[Hugo] add file option to schedule shortcode

### DIFF
--- a/hugo/hugo-lecture/layouts/shortcodes/schedule.html
+++ b/hugo/hugo-lecture/layouts/shortcodes/schedule.html
@@ -1,8 +1,5 @@
-{{ $plan := .Site.Data.schedule }}
-{{ if .Site.IsMultiLingual }}
-    {{ $data := index .Site.Data .Site.Language.Lang }}
-    {{ $plan = $data.schedule }}
-{{ end }}
+{{ $file := .Get "file" | default "schedule" }}
+{{ $plan := index .Site.Data $file }}
 
 {{ $if_misc_column := false }}
 {{ range $plan }}{{ with index . "misc_column" }}{{ $if_misc_column = true }}{{ end }}{{ end }}


### PR DESCRIPTION
This shortcode can be used without an additional option, i.e. like `{< schedule >}`. This will evaluate the schedule in `data/schedule.yaml`. 

To allow different schedules in joint lectures, this PR introduces the optional `file` option to specify the file name of the schedule, i.e. like `{< schedule file="schedule_hsbi" >}}`. In this example, the schedule is generated from `data/schedule_hsbi.yaml`. 

Here is an example of use:

```markdown
    ```{=markdown}
    {{< tabs >}}
    {{< tab title="ALT" >}}
    {{< schedule >}}
    {{< /tab >}}
    {{< tab title="TDU" >}}
    {{< schedule file="schedule_tdu" >}}
    <b>Hinweis</b>: Abgabe der Hausaufgaben bis jeweils XX:XX Uhr (TR), Deadline für das Feedback je bis XX:XX Uhr (TR) am angegebenen Tag (jeweils im Google Classroom).
    {{< /tab >}}
    {{< tab title="HSBI" >}}
    {{< schedule file="schedule_hsbi" >}}
    <b>Hinweis</b>: Abgabe der Hausaufgaben bis jeweils XX:XX Uhr (DE), Deadline für das Feedback je bis XX:XX Uhr (DE) am angegebenen Tag (jeweils im ILIAS).
    {{< /tab >}}
    {{< /tabs >}}
    ```
```

This produces three tabs with three different schedules, one with the default behaviour (`data/schedule.yaml`) and two with an explicitly specified file (`data/schedule_tdu.yaml` and `data/schedule_hsbi.yaml`).
