### PR TITLE
[Hugo] fix usage of notice shortcode (from Relearn theme) in partials - API change

### DIFF
--- a/hugo/hugo-lecture/layouts/partials/assignments.html
+++ b/hugo/hugo-lecture/layouts/partials/assignments.html
@@ -28,7 +28,7 @@
     {{ $c = printf "%s</ul>" $c }}
 
     {{ partial "shortcodes/notice.html" (dict
-        "context" .
+        "page" .
         "style" "note"
         "icon" "fas fa-laptop-code"
         "title" "Übungsblätter/Aufgaben"

--- a/hugo/hugo-lecture/layouts/partials/attachments.html
+++ b/hugo/hugo-lecture/layouts/partials/attachments.html
@@ -41,7 +41,7 @@
     {{ $c = printf "%s</ul>" $c }}
 
     {{ partial "shortcodes/notice.html" (dict
-        "context" .
+        "page" .
         "style" "info"
         "icon" "far fa-file-powerpoint"
         "title" $title

--- a/hugo/hugo-lecture/layouts/partials/bib.html
+++ b/hugo/hugo-lecture/layouts/partials/bib.html
@@ -53,7 +53,7 @@
     {{ $c = printf "%s</ul>" $c }}
 
     {{ partial "shortcodes/notice.html" (dict
-        "context" .
+        "page" .
         "style" "info"
         "icon" "fas fa-book-reader"
         "title" "Quellen"

--- a/hugo/hugo-lecture/layouts/partials/challenges.html
+++ b/hugo/hugo-lecture/layouts/partials/challenges.html
@@ -5,7 +5,7 @@
     {{ $c := $challenges | markdownify }}
 
     {{ partial "shortcodes/notice.html" (dict
-        "context" .
+        "page" .
         "style" "note"
         "icon" "fas fa-puzzle-piece"
         "title" "Challenges"

--- a/hugo/hugo-lecture/layouts/partials/outcomes.html
+++ b/hugo/hugo-lecture/layouts/partials/outcomes.html
@@ -12,7 +12,7 @@
     {{ $c = printf "%s</ul>" $c }}
 
     {{ partial "shortcodes/notice.html" (dict
-        "context" .
+        "page" .
         "style" "tip"
         "icon" "fas fa-lightbulb"
         "title" "Lernziele"

--- a/hugo/hugo-lecture/layouts/partials/quizzes.html
+++ b/hugo/hugo-lecture/layouts/partials/quizzes.html
@@ -13,7 +13,7 @@
     {{ $c = printf "%s</ul>" $c }}
 
     {{ partial "shortcodes/notice.html" (dict
-        "context" .
+        "page" .
         "style" "tip"
         "icon" "fas fa-user-check"
         "title" "Quizzes"

--- a/hugo/hugo-lecture/layouts/partials/tldr.html
+++ b/hugo/hugo-lecture/layouts/partials/tldr.html
@@ -5,7 +5,7 @@
     {{ $c := $tldr | markdownify }}
 
     {{ partial "shortcodes/notice.html" (dict
-        "context" .
+        "page" .
         "style" "info"
         "icon" "fas fa-graduation-cap"
         "title" "TL;DR"

--- a/hugo/hugo-lecture/layouts/partials/videos.html
+++ b/hugo/hugo-lecture/layouts/partials/videos.html
@@ -14,7 +14,7 @@
     {{ $c = printf "%s</ul>" $c }}
 
     {{ partial "shortcodes/notice.html" (dict
-        "context" .
+        "page" .
         "style" "info"
         "icon" "fas fa-podcast"
         "title" $title


### PR DESCRIPTION
According to https://mcshelby.github.io/hugo-theme-relearn/basics/migration/#5180 (see also https://github.com/McShelby/hugo-theme-relearn/issues/595 and https://github.com/McShelby/hugo-theme-relearn/pull/578) we have to use the parameter 'page' now instead of 'context'. Annoying. We really should switch to mdBook :/