### PR TITLE
[Filter] remove deprecated filter from slides default

### DIFF
--- a/defaults/slides.yaml
+++ b/defaults/slides.yaml
@@ -28,7 +28,6 @@ include-in-header:
 - resources/beamer.tex
 
 filters:
-- deprecated.lua
 - prepareSlides.lua
 - listings.lua
 - tex.lua


### PR DESCRIPTION
Slide defaults (Beamer): It's been a long time now, so everyone should be using the current commands and divs/spans. Let's clean it up a bit and remove the call to `deprecated.lua`.