### PR TITLE
[Filter] add rewritelinks filter: transform image src and link targets in markdown files (recursively)

### DIFF
--- a/filters/hugo_rewritelinks.lua
+++ b/filters/hugo_rewritelinks.lua
@@ -1,0 +1,93 @@
+--[[
+All 'readme.md' will be transformed into '_index.md', any other Markdown file
+'file.md' will be transformed into 'file/_index.md' (see 'hugo_makedeps.lua').
+
+This filter will adapt the image sources and the link targets in a Markdown
+file so that Hugo can build a web page from it.
+]]--
+
+
+-- local vars
+local INDEX_MD = "readme"       -- name of readme.md (will be set from metadata)
+
+
+
+-- helper
+local function _is_relative (target)
+    return pandoc.path.is_relative(target)
+end
+
+local function _is_markdown (target)
+    return target:match('.*%.md')
+end
+
+local function _is_url (target)
+    return target:match('https?://.*')
+end
+
+
+
+-- replace `![](img/b.png)` with `![](b.png)`
+function Image (image)
+    if _is_relative(image.src) and not _is_url(image.src) then
+        image.src = pandoc.path.filename(image.src)
+        return image
+    end
+end
+
+
+
+--[[
+Hugo's ref shortcode tries to resolve paths without a leading '/' first relative to the current page,
+then to the rest of the site. As long as all pages have a _unique name_, we can also simply use the
+name of the page. Index pages ('_index.md') must be referenced via their toplevel folder.
+
+All files will be transformed during processing (see 'hugo_makedeps.lua'):
+-   'subdir/file-a.md' will become 'subdir/file-a/_index.md'
+-   'subdir/readme.md' will become 'subdir/_index.md'
+
+Since "subdir" might contain something like "../", we would have to resolve this first. However, as
+Hugo's ref shortcode can also resolve just the filename without a path, we can skip this effort and
+just replace the path with the filename. For index files ('readme.md'), we have to extract the last
+folder.
+
+This filter need to perform for any link in any Markdown file:
+-   replace  `[Y](subdir/file-a.md)`  with  `[Y]({{< ref "file-a" >}})`
+-   replace  `[Y](subdir/readme.md)`  with  `[Y]({{< ref "subdir" >}})`
+-   replace  `[Y](readme.md)`         with  `[Y]({{< ref "/" >}})` (might work with Hugo)
+
+Caveats:
+(a) All referenced Markdown files must have UNIQUE NAMES.
+(b) References to the top index page (landing page) are (presumably) not working.
+]]--
+function Link (link)
+    local target = link.target
+    local content = pandoc.utils.stringify(link.content)
+
+    if _is_markdown(target) and _is_relative(target) and not _is_url(target) then
+        local dir = pandoc.path.split(pandoc.path.directory(target))        -- 'foo.md' => {'.'}; 'sub/foo.md' => {'sub'}; './sub/foo.md' => {'.', 'sub'};
+        local name, _ = pandoc.path.split_extension(pandoc.path.filename(target))
+
+        if name == INDEX_MD then
+            target = (#dir >= 1 and dir[#dir] ~= ".") and dir[#dir] or "/"  -- readme.md: use parent folder or '/'
+        else
+            target = name                                                   -- ordinary file: use it's name w/o extension
+        end
+
+        return pandoc.RawInline('markdown', '[' .. content .. ']({{< ref "' .. target .. '" >}})')
+    end
+end
+
+
+
+function Meta (m)
+    INDEX_MD = m.indexMD or "readme"
+end
+
+
+
+return {
+    { Meta = Meta },
+    { Image = Image },
+    { Link = Link }
+}

--- a/filters/test filter/Makefile
+++ b/filters/test filter/Makefile
@@ -1,12 +1,24 @@
 DIFF ?= diff --strip-trailing-cr -u
 PANDOC ?= pandoc
 
+FILES_TRANSFORM = readme.md
 FILES_MAKEDEPS  = readme.md
 
+LUA_REWRITELINKS = ../hugo_rewritelinks.lua
 LUA_MAKEDEPS     = ../hugo_makedeps.lua
 
 
-test: test_makedeps
+test: test_rewritelinks test_makedeps
+
+test_rewritelinks: $(FILES_TRANSFORM)
+	@$(PANDOC) -L $(LUA_REWRITELINKS) -t native $^                                        \
+	    | $(DIFF) expected_rewritelinks1.native -
+	@$(PANDOC) -L $(LUA_REWRITELINKS) -M indexMD="foo" -t native $^                       \
+	    | $(DIFF) expected_rewritelinks2.native -
+	@$(PANDOC) -L $(LUA_REWRITELINKS) -M indexMD="readme" -t native $^                    \
+	    | $(DIFF) expected_rewritelinks3.native -
+	@$(PANDOC) -L $(LUA_REWRITELINKS) -M weight=42 -M indexMD="readme" -t native $^       \
+	    | $(DIFF) expected_rewritelinks4.native -
 
 test_makedeps: $(FILES_MAKEDEPS)
 	@$(PANDOC) -L $(LUA_MAKEDEPS) -t native $^                                            \
@@ -18,6 +30,16 @@ test_makedeps: $(FILES_MAKEDEPS)
 	@$(PANDOC) -L $(LUA_MAKEDEPS) -M prefix="foobar" -M indexMD="readme" -t native $^     \
 	    | $(DIFF) expected_makedeps4.native -
 
+
+expected: expected_rewritelinks1.native expected_rewritelinks2.native expected_rewritelinks3.native expected_rewritelinks4.native
+expected_rewritelinks1.native: $(FILES_TRANSFORM)
+	$(PANDOC) -L $(LUA_REWRITELINKS) -t native -o $@ $^
+expected_rewritelinks2.native: $(FILES_TRANSFORM)
+	$(PANDOC) -L $(LUA_REWRITELINKS) -M indexMD="foo" -t native -o $@ $^
+expected_rewritelinks3.native: $(FILES_TRANSFORM)
+	$(PANDOC) -L $(LUA_REWRITELINKS) -M indexMD="readme" -t native -o $@ $^
+expected_rewritelinks4.native: $(FILES_TRANSFORM)
+	$(PANDOC) -L $(LUA_REWRITELINKS) -M weight=42 -M indexMD="readme" -t native -o $@ $^
 
 expected: expected_makedeps1.native expected_makedeps2.native expected_makedeps3.native expected_makedeps4.native
 expected_makedeps1.native: $(FILES_MAKEDEPS)
@@ -31,6 +53,7 @@ expected_makedeps4.native: $(FILES_MAKEDEPS)
 
 
 clean:
+	rm -rf expected_rewritelinks1.native expected_rewritelinks2.native expected_rewritelinks3.native expected_rewritelinks4.native
 	rm -rf expected_makedeps1.native expected_makedeps2.native expected_makedeps3.native expected_makedeps4.native
 
-.PHONY: test test_makedeps expected clean
+.PHONY: test test_rewritelinks test_makedeps expected clean

--- a/filters/test filter/expected_rewritelinks1.native
+++ b/filters/test filter/expected_rewritelinks1.native
@@ -1,0 +1,154 @@
+[ Header 1 ( "summary.md" , [] , [] ) [ Str "Summary.md" ]
+, Header
+    2
+    ( "this-should-work" , [] , [] )
+    [ Str "This" , Space , Str "should" , Space , Str "work" ]
+, Para [ Str "Thanks" , Space , Str "everyone!" ]
+, Para
+    [ RawInline
+        (Format "markdown") "[File A]({{< ref \"file-a\" >}})"
+    ]
+, Para
+    [ RawInline
+        (Format "markdown") "[File A]({{< ref \"file-a\" >}})"
+    ]
+, Figure
+    ( "" , [] , [] )
+    (Caption
+       Nothing
+       [ Plain
+           [ Str "Image"
+           , Space
+           , Str "A"
+           , Space
+           , Str "(from"
+           , Space
+           , Str "Readme.md)"
+           ]
+       ])
+    [ Plain
+        [ Image
+            ( "" , [] , [] )
+            [ Str "Image"
+            , Space
+            , Str "A"
+            , Space
+            , Str "(from"
+            , Space
+            , Str "Readme.md)"
+            ]
+            ( "a.png" , "" )
+        ]
+    ]
+, Para [ Image ( "" , [] , [] ) [] ( "a.png" , "" ) ]
+, Header
+    2
+    ( "different-wrong-format" , [] , [] )
+    [ Str "Different"
+    , Space
+    , Str "(wrong)"
+    , Space
+    , Str "format"
+    ]
+, BulletList
+    [ [ Plain
+          [ Link
+              ( "" , [] , [] )
+              [ Str "wrong" , Space , Str "extension" ]
+              ( "file-c.png" , "" )
+          ]
+      ]
+    , [ Plain
+          [ Link
+              ( "" , [] , [] )
+              [ Str "not" , Space , Str "local" ]
+              ( "https://pandoc.org/lua-filters.html" , "" )
+          ]
+      ]
+    , [ Plain
+          [ Link
+              ( "" , [] , [] )
+              [ Str "still" , Space , Str "not" , Space , Str "local" ]
+              ( "https://pandoc.org/lua-filters.md" , "" )
+          ]
+      ]
+    , [ Plain
+          [ Link
+              ( "" , [] , [] )
+              [ Str "also" , Space , Str "not" , Space , Str "local" ]
+              ( "http://pandoc.org/lua-filters.md" , "" )
+          ]
+      ]
+    , [ Plain
+          [ RawInline
+              (Format "markdown")
+              "[not there and not here]({{< ref \"wuppie\" >}})"
+          ]
+      ]
+    ]
+, Header
+    2
+    ( "recursive-inclusion" , [] , [] )
+    [ Str "Recursive" , Space , Str "inclusion" ]
+, Para
+    [ RawInline
+        (Format "markdown") "[File B]({{< ref \"file-b\" >}})"
+    ]
+, Header
+    2 ( "subdirectories" , [] , [] ) [ Str "Subdirectories" ]
+, Para
+    [ RawInline
+        (Format "markdown")
+        "[Subdir: File D]({{< ref \"file-d\" >}})"
+    ]
+, Para
+    [ RawInline
+        (Format "markdown")
+        "[Subdir: File D]({{< ref \"file-d\" >}})"
+    ]
+, Header
+    2
+    ( "subdirectories-recursive" , [] , [] )
+    [ Str "Subdirectories," , Space , Str "recursive" ]
+, Para
+    [ RawInline
+        (Format "markdown")
+        "[Subdir: File E]({{< ref \"file-e\" >}})"
+    ]
+, Header
+    2
+    ( "subdirectories-direct-plus-recursive" , [] , [] )
+    [ Str "Subdirectories,"
+    , Space
+    , Str "direct"
+    , Space
+    , Str "plus"
+    , Space
+    , Str "recursive"
+    ]
+, Para
+    [ RawInline
+        (Format "markdown")
+        "[Subdir/Leaf: Foo]({{< ref \"foo\" >}})"
+    ]
+, Header
+    2
+    ( "links-to-landing-pages" , [] , [] )
+    [ Str "Links"
+    , Space
+    , Str "to"
+    , Space
+    , Str "Landing"
+    , Space
+    , Str "Pages"
+    ]
+, Para
+    [ RawInline
+        (Format "markdown")
+        "[subdir/readme]({{< ref \"subdir\" >}})"
+    ]
+, Para
+    [ RawInline
+        (Format "markdown") "[readme]({{< ref \"/\" >}})"
+    ]
+]

--- a/filters/test filter/expected_rewritelinks2.native
+++ b/filters/test filter/expected_rewritelinks2.native
@@ -1,0 +1,154 @@
+[ Header 1 ( "summary.md" , [] , [] ) [ Str "Summary.md" ]
+, Header
+    2
+    ( "this-should-work" , [] , [] )
+    [ Str "This" , Space , Str "should" , Space , Str "work" ]
+, Para [ Str "Thanks" , Space , Str "everyone!" ]
+, Para
+    [ RawInline
+        (Format "markdown") "[File A]({{< ref \"file-a\" >}})"
+    ]
+, Para
+    [ RawInline
+        (Format "markdown") "[File A]({{< ref \"file-a\" >}})"
+    ]
+, Figure
+    ( "" , [] , [] )
+    (Caption
+       Nothing
+       [ Plain
+           [ Str "Image"
+           , Space
+           , Str "A"
+           , Space
+           , Str "(from"
+           , Space
+           , Str "Readme.md)"
+           ]
+       ])
+    [ Plain
+        [ Image
+            ( "" , [] , [] )
+            [ Str "Image"
+            , Space
+            , Str "A"
+            , Space
+            , Str "(from"
+            , Space
+            , Str "Readme.md)"
+            ]
+            ( "a.png" , "" )
+        ]
+    ]
+, Para [ Image ( "" , [] , [] ) [] ( "a.png" , "" ) ]
+, Header
+    2
+    ( "different-wrong-format" , [] , [] )
+    [ Str "Different"
+    , Space
+    , Str "(wrong)"
+    , Space
+    , Str "format"
+    ]
+, BulletList
+    [ [ Plain
+          [ Link
+              ( "" , [] , [] )
+              [ Str "wrong" , Space , Str "extension" ]
+              ( "file-c.png" , "" )
+          ]
+      ]
+    , [ Plain
+          [ Link
+              ( "" , [] , [] )
+              [ Str "not" , Space , Str "local" ]
+              ( "https://pandoc.org/lua-filters.html" , "" )
+          ]
+      ]
+    , [ Plain
+          [ Link
+              ( "" , [] , [] )
+              [ Str "still" , Space , Str "not" , Space , Str "local" ]
+              ( "https://pandoc.org/lua-filters.md" , "" )
+          ]
+      ]
+    , [ Plain
+          [ Link
+              ( "" , [] , [] )
+              [ Str "also" , Space , Str "not" , Space , Str "local" ]
+              ( "http://pandoc.org/lua-filters.md" , "" )
+          ]
+      ]
+    , [ Plain
+          [ RawInline
+              (Format "markdown")
+              "[not there and not here]({{< ref \"wuppie\" >}})"
+          ]
+      ]
+    ]
+, Header
+    2
+    ( "recursive-inclusion" , [] , [] )
+    [ Str "Recursive" , Space , Str "inclusion" ]
+, Para
+    [ RawInline
+        (Format "markdown") "[File B]({{< ref \"file-b\" >}})"
+    ]
+, Header
+    2 ( "subdirectories" , [] , [] ) [ Str "Subdirectories" ]
+, Para
+    [ RawInline
+        (Format "markdown")
+        "[Subdir: File D]({{< ref \"file-d\" >}})"
+    ]
+, Para
+    [ RawInline
+        (Format "markdown")
+        "[Subdir: File D]({{< ref \"file-d\" >}})"
+    ]
+, Header
+    2
+    ( "subdirectories-recursive" , [] , [] )
+    [ Str "Subdirectories," , Space , Str "recursive" ]
+, Para
+    [ RawInline
+        (Format "markdown")
+        "[Subdir: File E]({{< ref \"file-e\" >}})"
+    ]
+, Header
+    2
+    ( "subdirectories-direct-plus-recursive" , [] , [] )
+    [ Str "Subdirectories,"
+    , Space
+    , Str "direct"
+    , Space
+    , Str "plus"
+    , Space
+    , Str "recursive"
+    ]
+, Para
+    [ RawInline
+        (Format "markdown")
+        "[Subdir/Leaf: Foo]({{< ref \"leaf\" >}})"
+    ]
+, Header
+    2
+    ( "links-to-landing-pages" , [] , [] )
+    [ Str "Links"
+    , Space
+    , Str "to"
+    , Space
+    , Str "Landing"
+    , Space
+    , Str "Pages"
+    ]
+, Para
+    [ RawInline
+        (Format "markdown")
+        "[subdir/readme]({{< ref \"readme\" >}})"
+    ]
+, Para
+    [ RawInline
+        (Format "markdown") "[readme]({{< ref \"readme\" >}})"
+    ]
+]

--- a/filters/test filter/expected_rewritelinks3.native
+++ b/filters/test filter/expected_rewritelinks3.native
@@ -1,0 +1,154 @@
+[ Header 1 ( "summary.md" , [] , [] ) [ Str "Summary.md" ]
+, Header
+    2
+    ( "this-should-work" , [] , [] )
+    [ Str "This" , Space , Str "should" , Space , Str "work" ]
+, Para [ Str "Thanks" , Space , Str "everyone!" ]
+, Para
+    [ RawInline
+        (Format "markdown") "[File A]({{< ref \"file-a\" >}})"
+    ]
+, Para
+    [ RawInline
+        (Format "markdown") "[File A]({{< ref \"file-a\" >}})"
+    ]
+, Figure
+    ( "" , [] , [] )
+    (Caption
+       Nothing
+       [ Plain
+           [ Str "Image"
+           , Space
+           , Str "A"
+           , Space
+           , Str "(from"
+           , Space
+           , Str "Readme.md)"
+           ]
+       ])
+    [ Plain
+        [ Image
+            ( "" , [] , [] )
+            [ Str "Image"
+            , Space
+            , Str "A"
+            , Space
+            , Str "(from"
+            , Space
+            , Str "Readme.md)"
+            ]
+            ( "a.png" , "" )
+        ]
+    ]
+, Para [ Image ( "" , [] , [] ) [] ( "a.png" , "" ) ]
+, Header
+    2
+    ( "different-wrong-format" , [] , [] )
+    [ Str "Different"
+    , Space
+    , Str "(wrong)"
+    , Space
+    , Str "format"
+    ]
+, BulletList
+    [ [ Plain
+          [ Link
+              ( "" , [] , [] )
+              [ Str "wrong" , Space , Str "extension" ]
+              ( "file-c.png" , "" )
+          ]
+      ]
+    , [ Plain
+          [ Link
+              ( "" , [] , [] )
+              [ Str "not" , Space , Str "local" ]
+              ( "https://pandoc.org/lua-filters.html" , "" )
+          ]
+      ]
+    , [ Plain
+          [ Link
+              ( "" , [] , [] )
+              [ Str "still" , Space , Str "not" , Space , Str "local" ]
+              ( "https://pandoc.org/lua-filters.md" , "" )
+          ]
+      ]
+    , [ Plain
+          [ Link
+              ( "" , [] , [] )
+              [ Str "also" , Space , Str "not" , Space , Str "local" ]
+              ( "http://pandoc.org/lua-filters.md" , "" )
+          ]
+      ]
+    , [ Plain
+          [ RawInline
+              (Format "markdown")
+              "[not there and not here]({{< ref \"wuppie\" >}})"
+          ]
+      ]
+    ]
+, Header
+    2
+    ( "recursive-inclusion" , [] , [] )
+    [ Str "Recursive" , Space , Str "inclusion" ]
+, Para
+    [ RawInline
+        (Format "markdown") "[File B]({{< ref \"file-b\" >}})"
+    ]
+, Header
+    2 ( "subdirectories" , [] , [] ) [ Str "Subdirectories" ]
+, Para
+    [ RawInline
+        (Format "markdown")
+        "[Subdir: File D]({{< ref \"file-d\" >}})"
+    ]
+, Para
+    [ RawInline
+        (Format "markdown")
+        "[Subdir: File D]({{< ref \"file-d\" >}})"
+    ]
+, Header
+    2
+    ( "subdirectories-recursive" , [] , [] )
+    [ Str "Subdirectories," , Space , Str "recursive" ]
+, Para
+    [ RawInline
+        (Format "markdown")
+        "[Subdir: File E]({{< ref \"file-e\" >}})"
+    ]
+, Header
+    2
+    ( "subdirectories-direct-plus-recursive" , [] , [] )
+    [ Str "Subdirectories,"
+    , Space
+    , Str "direct"
+    , Space
+    , Str "plus"
+    , Space
+    , Str "recursive"
+    ]
+, Para
+    [ RawInline
+        (Format "markdown")
+        "[Subdir/Leaf: Foo]({{< ref \"foo\" >}})"
+    ]
+, Header
+    2
+    ( "links-to-landing-pages" , [] , [] )
+    [ Str "Links"
+    , Space
+    , Str "to"
+    , Space
+    , Str "Landing"
+    , Space
+    , Str "Pages"
+    ]
+, Para
+    [ RawInline
+        (Format "markdown")
+        "[subdir/readme]({{< ref \"subdir\" >}})"
+    ]
+, Para
+    [ RawInline
+        (Format "markdown") "[readme]({{< ref \"/\" >}})"
+    ]
+]

--- a/filters/test filter/expected_rewritelinks4.native
+++ b/filters/test filter/expected_rewritelinks4.native
@@ -1,0 +1,154 @@
+[ Header 1 ( "summary.md" , [] , [] ) [ Str "Summary.md" ]
+, Header
+    2
+    ( "this-should-work" , [] , [] )
+    [ Str "This" , Space , Str "should" , Space , Str "work" ]
+, Para [ Str "Thanks" , Space , Str "everyone!" ]
+, Para
+    [ RawInline
+        (Format "markdown") "[File A]({{< ref \"file-a\" >}})"
+    ]
+, Para
+    [ RawInline
+        (Format "markdown") "[File A]({{< ref \"file-a\" >}})"
+    ]
+, Figure
+    ( "" , [] , [] )
+    (Caption
+       Nothing
+       [ Plain
+           [ Str "Image"
+           , Space
+           , Str "A"
+           , Space
+           , Str "(from"
+           , Space
+           , Str "Readme.md)"
+           ]
+       ])
+    [ Plain
+        [ Image
+            ( "" , [] , [] )
+            [ Str "Image"
+            , Space
+            , Str "A"
+            , Space
+            , Str "(from"
+            , Space
+            , Str "Readme.md)"
+            ]
+            ( "a.png" , "" )
+        ]
+    ]
+, Para [ Image ( "" , [] , [] ) [] ( "a.png" , "" ) ]
+, Header
+    2
+    ( "different-wrong-format" , [] , [] )
+    [ Str "Different"
+    , Space
+    , Str "(wrong)"
+    , Space
+    , Str "format"
+    ]
+, BulletList
+    [ [ Plain
+          [ Link
+              ( "" , [] , [] )
+              [ Str "wrong" , Space , Str "extension" ]
+              ( "file-c.png" , "" )
+          ]
+      ]
+    , [ Plain
+          [ Link
+              ( "" , [] , [] )
+              [ Str "not" , Space , Str "local" ]
+              ( "https://pandoc.org/lua-filters.html" , "" )
+          ]
+      ]
+    , [ Plain
+          [ Link
+              ( "" , [] , [] )
+              [ Str "still" , Space , Str "not" , Space , Str "local" ]
+              ( "https://pandoc.org/lua-filters.md" , "" )
+          ]
+      ]
+    , [ Plain
+          [ Link
+              ( "" , [] , [] )
+              [ Str "also" , Space , Str "not" , Space , Str "local" ]
+              ( "http://pandoc.org/lua-filters.md" , "" )
+          ]
+      ]
+    , [ Plain
+          [ RawInline
+              (Format "markdown")
+              "[not there and not here]({{< ref \"wuppie\" >}})"
+          ]
+      ]
+    ]
+, Header
+    2
+    ( "recursive-inclusion" , [] , [] )
+    [ Str "Recursive" , Space , Str "inclusion" ]
+, Para
+    [ RawInline
+        (Format "markdown") "[File B]({{< ref \"file-b\" >}})"
+    ]
+, Header
+    2 ( "subdirectories" , [] , [] ) [ Str "Subdirectories" ]
+, Para
+    [ RawInline
+        (Format "markdown")
+        "[Subdir: File D]({{< ref \"file-d\" >}})"
+    ]
+, Para
+    [ RawInline
+        (Format "markdown")
+        "[Subdir: File D]({{< ref \"file-d\" >}})"
+    ]
+, Header
+    2
+    ( "subdirectories-recursive" , [] , [] )
+    [ Str "Subdirectories," , Space , Str "recursive" ]
+, Para
+    [ RawInline
+        (Format "markdown")
+        "[Subdir: File E]({{< ref \"file-e\" >}})"
+    ]
+, Header
+    2
+    ( "subdirectories-direct-plus-recursive" , [] , [] )
+    [ Str "Subdirectories,"
+    , Space
+    , Str "direct"
+    , Space
+    , Str "plus"
+    , Space
+    , Str "recursive"
+    ]
+, Para
+    [ RawInline
+        (Format "markdown")
+        "[Subdir/Leaf: Foo]({{< ref \"foo\" >}})"
+    ]
+, Header
+    2
+    ( "links-to-landing-pages" , [] , [] )
+    [ Str "Links"
+    , Space
+    , Str "to"
+    , Space
+    , Str "Landing"
+    , Space
+    , Str "Pages"
+    ]
+, Para
+    [ RawInline
+        (Format "markdown")
+        "[subdir/readme]({{< ref \"subdir\" >}})"
+    ]
+, Para
+    [ RawInline
+        (Format "markdown") "[readme]({{< ref \"/\" >}})"
+    ]
+]


### PR DESCRIPTION
This is the second part of #115: Add a filter, that

- transforms all 'readme.md' into '_index.md', any other Markdown file 'file.md' will be transformed into 'file/_index.md' (see 'hugo_makedeps.lua')
- will adapt the image sources and the link targets in a Markdown file so that Hugo can build a web page from it

