### PR TITLE
[Filter] change makedeps to allow '../' in paths

### DIFF
--- a/demo/hugo-lecture/readme.md
+++ b/demo/hugo-lecture/readme.md
@@ -121,6 +121,5 @@ referenced pages will be available in the site, however.
 
 -   [Syllabus](orga/syllabus.md)
 -   [Ressourcen](orga/resources.md)
--   [Note und Credits](orga/grading.md)
 -   [Prüfungsvorbereitung](orga/exams.md)
 :::

--- a/demo/hugo-lecture/subdir/file-d.md
+++ b/demo/hugo-lecture/subdir/file-d.md
@@ -3,3 +3,5 @@ title: "Subdir/File-D.md"
 ---
 
 Wuppie!
+
+[link to ../orga/grading](../orga/grading.md)

--- a/filters/hugo_makedeps.lua
+++ b/filters/hugo_makedeps.lua
@@ -147,12 +147,12 @@ end
 
 
 -- queue
-local function _push (path)
+local function _enqueue (path)
     lqlast = lqlast + 1
     lqueue[lqlast] = path
 end
 
-local function _pop ()
+local function _dequeue ()
     local path = nil
     if lqfirst <= lqlast then
         path = lqueue[lqfirst]
@@ -206,7 +206,7 @@ local function _process_doc (blocks, md_file, include_path)
         _remember_file(include_path, md_file, newl)
 
         -- enqueue local landing page "include_path/readme.md" for later processing
-        _push(_old_path(include_path, INDEX_MD .. ".md"))
+        _enqueue(_old_path(include_path, INDEX_MD .. ".md"))
 
         -- collect and enqueue all new images and links in this file 'include_path/md_file'
         local collect_images_links = {
@@ -219,7 +219,7 @@ local function _process_doc (blocks, md_file, include_path)
             Link = function (link)
                 if _is_markdown(link.target) and _is_relative(link.target) and not _is_url(link.target) then
                     -- enqueue "include_path/link.target" for later processing
-                    _push(_old_path(include_path, link.target))
+                    _enqueue(_old_path(include_path, link.target))
                 end
             end
         }
@@ -288,10 +288,10 @@ function Pandoc (doc)
     _process_doc(doc.blocks, INDEX_MD, ".")
 
     -- process files recursively: breadth-first search
-    local oldl = _pop()
+    local oldl = _dequeue()
     while oldl do
         _handle_file(oldl)
-        oldl = _pop()
+        oldl = _dequeue()
     end
 
     -- emit dependency makefile

--- a/filters/hugo_makedeps.lua
+++ b/filters/hugo_makedeps.lua
@@ -111,7 +111,7 @@ local lqlast = -1               -- last element in queue
 
 local PREFIX = "."              -- string to prepend to the new locations, e.g. temporary folder (will be set from metadata)
 local INDEX_MD = "readme"       -- name of readme.md (will be set from metadata)
-
+local ROOT = "."
 
 
 -- helper
@@ -145,6 +145,8 @@ local function _filename_woext (target)
     return name
 end
 
+
+-- queue
 local function _push (path)
     lqlast = lqlast + 1
     lqueue[lqlast] = path
@@ -160,32 +162,33 @@ local function _pop ()
     return path
 end
 
-local function _remember_me (md_file, include_path)
-    -- remember this file
+
+-- processing of markdown files, links and images
+local function _remember_file (include_path, md_file, newl)
     -- safe as PREFIX/include_path/(md_file?)/_index.md: include_path/(md_file .. ".md")
     local oldl = _old_path(include_path, md_file .. ".md")
-    local newl = _new_path_idx(include_path, md_file)
 
     if not links[newl] then
         weights[#weights + 1] = newl
         links[newl] = oldl
     else
-        io.stderr:write("\t (_remember_me) new path '" .. newl .. "' (from '" .. oldl .. "') has been already processed ... this should not happen ... \n")
+        io.stderr:write("\t (_remember_file) new path '" .. newl .. "' (from '" .. oldl .. "') has been already processed ... THIS SHOULD NOT HAPPEN ... \n")
     end
 end
 
-local function _read_file (target)
-    local fh = io.open(target, "r")
-    if not fh then
-        io.stderr:write("\t (_read_file) cannot open file '" .. target .. " ... skipping ... \n")
-    else
-        local content = fh:read "*all"
-        fh:close()
-        return pandoc.read(content, "markdown", PANDOC_READER_OPTIONS).blocks
+local function _remember_image (include_path, md_file, image_src, newl)
+    -- safe as PREFIX/include_path/(md_file?)/file(image_src): include_path/image_src
+    local oldi = _old_path(include_path, image_src)
+    local newi = _new_path(include_path, md_file, pandoc.path.filename(image_src))
+
+    if not images[newi] then
+        img[#img + 1] = newi    -- list: we want the same sequence for each run
+        images[newi] = oldi     -- set: do not store images twice
+
+        -- create a dependency for corresponding '_index.md'
+        link_img[newl] = link_img[newl] and (link_img[newl] .. " " .. newi) or (newi)
     end
 end
-
-
 
 --[[
 process Pandoc document (list of blocks):
@@ -193,47 +196,64 @@ process Pandoc document (list of blocks):
 (1) "save" link to current document, i.e. do not process this document again
 (2) collect all images and all links in this document (local, relative, not HTTP, links to Markdown files)
 ]]
-local function process_doc (blocks, md_file, include_path)
-    -- remember this file & folder
-    _remember_me(md_file, include_path)
+local function _process_doc (blocks, md_file, include_path)
+    -- new link: PREFIX/include_path/(md_file?)/_index.md
+    local newl = _new_path_idx(include_path, md_file)
 
-    -- enqueue "include_path/readme.md" for later processing
-    _push(_old_path(include_path, INDEX_MD .. ".md"))
+    -- if not already processed:
+    if not links[newl] then
+        -- remember this file
+        _remember_file(include_path, md_file, newl)
 
-    -- collect all new images and links in this file 'include_path/md_file'
-    local collect_images_links = {
-        -- do not refactor this into separate functions as we need 'md_file' and 'include_path' as closure
-        Image = function (image)
-            -- collect all new images in this file
-            -- safe as PREFIX/include_path/(md_file?)/file(img.src): include_path/img.src
-            if _is_relative(image.src) and not _is_url(image.src) then
-                local oldi = _old_path(include_path, image.src)
-                local newi = _new_path(include_path, md_file, pandoc.path.filename(image.src))
-                local newl = _new_path_idx(include_path, md_file)   -- corresponding _index.md
+        -- enqueue local landing page "include_path/readme.md" for later processing
+        _push(_old_path(include_path, INDEX_MD .. ".md"))
 
-                if not images[newi] then
-                    img[#img + 1] = newi    -- list: we want the same sequence for each run
-                    images[newi] = oldi     -- set: do not store images twice
-                    -- create a dependency for corresponding '_index.md'
-                    link_img[newl] = link_img[newl] and (link_img[newl] .. " " .. newi) or (newi)
+        -- collect and enqueue all new images and links in this file 'include_path/md_file'
+        local collect_images_links = {
+            Image = function (image)
+                if _is_relative(image.src) and not _is_url(image.src) then
+                    -- remember this image
+                    _remember_image(include_path, md_file, image.src, newl)
+                end
+            end,
+            Link = function (link)
+                if _is_markdown(link.target) and _is_relative(link.target) and not _is_url(link.target) then
+                    -- enqueue "include_path/link.target" for later processing
+                    _push(_old_path(include_path, link.target))
                 end
             end
-        end,
-        Link = function (link)
-            -- collect all new links in this file
-            -- safe as PREFIX/include_path/path(link.target)/file_woe(link.target)?/_index.md: include_path/link.target
-            if _is_markdown(link.target) and _is_relative(link.target) and not _is_url(link.target) then
-                -- enqueue "include_path/link.target" for later processing
-                _push(_old_path(include_path, link.target))
-            end
-        end
-    }
-    blocks:walk(collect_images_links)
+        }
+        blocks:walk(collect_images_links)
+    end
+end
+
+local function _read_file (fname)
+    local fh = io.open(fname, "r")
+    if not fh then
+        io.stderr:write("\t (_read_file) cannot open file '" .. fname .. " ... skipping ... \n")
+    else
+        local content = fh:read "*all"
+        fh:close()
+        return pandoc.read(content, "markdown", PANDOC_READER_OPTIONS).blocks
+    end
+end
+
+local function _handle_file (oldl)
+    local blocks = _read_file(oldl)
+
+    if blocks then
+        pandoc.system.with_working_directory(
+            pandoc.path.directory(oldl),    -- may still contain '../'
+            function ()
+                local wrkdir = pandoc.system.get_working_directory()    -- same as 'pandoc.path.directory(oldl)' but w/o '../' since Pandoc changed here
+                _process_doc(blocks, _filename_woext(oldl), pandoc.path.make_relative(wrkdir, ROOT))
+            end)
+    end
 end
 
 
-
-local function emit_images ()
+-- emit structures for make.deps
+local function _emit_images ()
     local inlines = pandoc.List:new()
     for _, newi in ipairs(img) do
         inlines:insert(pandoc.RawInline("markdown", newi .. ": " .. images[newi] .. "\n"))
@@ -242,9 +262,7 @@ local function emit_images ()
     return inlines
 end
 
-
-
-local function emit_links ()
+local function _emit_links ()
     local inlines = pandoc.List:new()
     for weight, newl in ipairs(weights) do
         inlines:insert(pandoc.RawInline("markdown", newl .. ": " .. links[newl] .. "\n"))
@@ -259,29 +277,23 @@ end
 
 
 
+-- main filter function
 function Pandoc (doc)
     -- init global vars using metadata: meta.prefix and meta.indexMD
     PREFIX = doc.meta.prefix or "."                     -- if not set, use "." and do no harm
     INDEX_MD = doc.meta.indexMD or "readme"             -- we do need the name w/o extension
+    ROOT = pandoc.system.get_working_directory()        -- remember our project root
 
     -- landing page: process all images and links
-    process_doc(doc.blocks, INDEX_MD, ".")
+    _process_doc(doc.blocks, INDEX_MD, ".")
 
     -- process files recursively: breadth-first search
     local oldl = _pop()
     while oldl do
-        local dir = pandoc.path.directory(oldl)
-        local name = _filename_woext(oldl)
-        local newl = _new_path_idx(dir, name)
-
-        if not links[newl] then
-            local blocks = _read_file(oldl)
-            if blocks then process_doc(blocks, name, dir) end
-        end
-
+        _handle_file(oldl)
         oldl = _pop()
     end
 
     -- emit dependency makefile
-    return pandoc.Pandoc({pandoc.Plain(emit_images()), pandoc.Plain(emit_links())}, doc.meta)
+    return pandoc.Pandoc({pandoc.Plain(_emit_images()), pandoc.Plain(_emit_links())}, doc.meta)
 end

--- a/filters/hugo_makedeps.lua
+++ b/filters/hugo_makedeps.lua
@@ -111,7 +111,7 @@ local lqlast = -1               -- last element in queue
 
 local PREFIX = "."              -- string to prepend to the new locations, e.g. temporary folder (will be set from metadata)
 local INDEX_MD = "readme"       -- name of readme.md (will be set from metadata)
-local ROOT = "."
+local ROOT = "."                -- absolute path to working directory when starting
 
 
 -- helper
@@ -195,7 +195,7 @@ process Pandoc document (list of blocks):
 
 (1) "save" link to current document, i.e. do not process this document again
 (2) collect all images and all links in this document (local, relative, not HTTP, links to Markdown files)
-]]
+]]--
 local function _process_doc (blocks, md_file, include_path)
     -- new link: PREFIX/include_path/(md_file?)/_index.md
     local newl = _new_path_idx(include_path, md_file)
@@ -245,7 +245,7 @@ local function _handle_file (oldl)
         pandoc.system.with_working_directory(
             pandoc.path.directory(oldl),    -- may still contain '../'
             function ()
-                local wrkdir = pandoc.system.get_working_directory()    -- same as 'pandoc.path.directory(oldl)' but w/o '../' since Pandoc changed here
+                local wrkdir = pandoc.system.get_working_directory()    -- same as 'pandoc.path.directory(oldl)' but w/o '../' since Pandoc cd'ed here
                 _process_doc(blocks, _filename_woext(oldl), pandoc.path.make_relative(wrkdir, ROOT))
             end)
     end

--- a/filters/test filter/expected_makedeps1.native
+++ b/filters/test filter/expected_makedeps1.native
@@ -127,20 +127,20 @@
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += orga/resources/_index.md\n\n"
     , RawInline
-        (Format "markdown")
-        "orga/grading/_index.md: orga/grading.md\n"
-    , RawInline
-        (Format "markdown") "orga/grading/_index.md: WEIGHT=10\n"
-    , RawInline
-        (Format "markdown")
-        "WEB_MARKDOWN_TARGETS += orga/grading/_index.md\n\n"
-    , RawInline
         (Format "markdown") "orga/exams/_index.md: orga/exams.md\n"
     , RawInline
-        (Format "markdown") "orga/exams/_index.md: WEIGHT=11\n"
+        (Format "markdown") "orga/exams/_index.md: WEIGHT=10\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += orga/exams/_index.md\n\n"
+    , RawInline
+        (Format "markdown")
+        "orga/grading/_index.md: orga/grading.md\n"
+    , RawInline
+        (Format "markdown") "orga/grading/_index.md: WEIGHT=11\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += orga/grading/_index.md\n\n"
     , RawInline
         (Format "markdown")
         "subdir/leaf/bar/_index.md: subdir/leaf/bar.md\n"

--- a/filters/test filter/expected_makedeps2.native
+++ b/filters/test filter/expected_makedeps2.native
@@ -137,20 +137,20 @@
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += orga/resources/_index.md\n\n"
     , RawInline
-        (Format "markdown")
-        "orga/grading/_index.md: orga/grading.md\n"
-    , RawInline
-        (Format "markdown") "orga/grading/_index.md: WEIGHT=11\n"
-    , RawInline
-        (Format "markdown")
-        "WEB_MARKDOWN_TARGETS += orga/grading/_index.md\n\n"
-    , RawInline
         (Format "markdown") "orga/exams/_index.md: orga/exams.md\n"
     , RawInline
-        (Format "markdown") "orga/exams/_index.md: WEIGHT=12\n"
+        (Format "markdown") "orga/exams/_index.md: WEIGHT=11\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += orga/exams/_index.md\n\n"
+    , RawInline
+        (Format "markdown")
+        "orga/grading/_index.md: orga/grading.md\n"
+    , RawInline
+        (Format "markdown") "orga/grading/_index.md: WEIGHT=12\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += orga/grading/_index.md\n\n"
     , RawInline
         (Format "markdown")
         "subdir/leaf/bar/_index.md: subdir/leaf/bar.md\n"

--- a/filters/test filter/expected_makedeps3.native
+++ b/filters/test filter/expected_makedeps3.native
@@ -127,20 +127,20 @@
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += orga/resources/_index.md\n\n"
     , RawInline
-        (Format "markdown")
-        "orga/grading/_index.md: orga/grading.md\n"
-    , RawInline
-        (Format "markdown") "orga/grading/_index.md: WEIGHT=10\n"
-    , RawInline
-        (Format "markdown")
-        "WEB_MARKDOWN_TARGETS += orga/grading/_index.md\n\n"
-    , RawInline
         (Format "markdown") "orga/exams/_index.md: orga/exams.md\n"
     , RawInline
-        (Format "markdown") "orga/exams/_index.md: WEIGHT=11\n"
+        (Format "markdown") "orga/exams/_index.md: WEIGHT=10\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += orga/exams/_index.md\n\n"
+    , RawInline
+        (Format "markdown")
+        "orga/grading/_index.md: orga/grading.md\n"
+    , RawInline
+        (Format "markdown") "orga/grading/_index.md: WEIGHT=11\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += orga/grading/_index.md\n\n"
     , RawInline
         (Format "markdown")
         "subdir/leaf/bar/_index.md: subdir/leaf/bar.md\n"

--- a/filters/test filter/expected_makedeps4.native
+++ b/filters/test filter/expected_makedeps4.native
@@ -144,22 +144,22 @@
         "WEB_MARKDOWN_TARGETS += foobar/orga/resources/_index.md\n\n"
     , RawInline
         (Format "markdown")
-        "foobar/orga/grading/_index.md: orga/grading.md\n"
-    , RawInline
-        (Format "markdown")
-        "foobar/orga/grading/_index.md: WEIGHT=10\n"
-    , RawInline
-        (Format "markdown")
-        "WEB_MARKDOWN_TARGETS += foobar/orga/grading/_index.md\n\n"
-    , RawInline
-        (Format "markdown")
         "foobar/orga/exams/_index.md: orga/exams.md\n"
     , RawInline
         (Format "markdown")
-        "foobar/orga/exams/_index.md: WEIGHT=11\n"
+        "foobar/orga/exams/_index.md: WEIGHT=10\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += foobar/orga/exams/_index.md\n\n"
+    , RawInline
+        (Format "markdown")
+        "foobar/orga/grading/_index.md: orga/grading.md\n"
+    , RawInline
+        (Format "markdown")
+        "foobar/orga/grading/_index.md: WEIGHT=11\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += foobar/orga/grading/_index.md\n\n"
     , RawInline
         (Format "markdown")
         "foobar/subdir/leaf/bar/_index.md: subdir/leaf/bar.md\n"

--- a/filters/test filter/expected_rewritelinks1.native
+++ b/filters/test filter/expected_rewritelinks1.native
@@ -399,12 +399,6 @@
         , [ Plain
               [ RawInline
                   (Format "markdown")
-                  "[Note und Credits]({{< ref \"grading\" >}})"
-              ]
-          ]
-        , [ Plain
-              [ RawInline
-                  (Format "markdown")
                   "[Pr\252fungsvorbereitung]({{< ref \"exams\" >}})"
               ]
           ]

--- a/filters/test filter/expected_rewritelinks2.native
+++ b/filters/test filter/expected_rewritelinks2.native
@@ -399,12 +399,6 @@
         , [ Plain
               [ RawInline
                   (Format "markdown")
-                  "[Note und Credits]({{< ref \"grading\" >}})"
-              ]
-          ]
-        , [ Plain
-              [ RawInline
-                  (Format "markdown")
                   "[Pr\252fungsvorbereitung]({{< ref \"exams\" >}})"
               ]
           ]

--- a/filters/test filter/expected_rewritelinks3.native
+++ b/filters/test filter/expected_rewritelinks3.native
@@ -399,12 +399,6 @@
         , [ Plain
               [ RawInline
                   (Format "markdown")
-                  "[Note und Credits]({{< ref \"grading\" >}})"
-              ]
-          ]
-        , [ Plain
-              [ RawInline
-                  (Format "markdown")
                   "[Pr\252fungsvorbereitung]({{< ref \"exams\" >}})"
               ]
           ]

--- a/filters/test filter/expected_rewritelinks4.native
+++ b/filters/test filter/expected_rewritelinks4.native
@@ -399,12 +399,6 @@
         , [ Plain
               [ RawInline
                   (Format "markdown")
-                  "[Note und Credits]({{< ref \"grading\" >}})"
-              ]
-          ]
-        , [ Plain
-              [ RawInline
-                  (Format "markdown")
                   "[Pr\252fungsvorbereitung]({{< ref \"exams\" >}})"
               ]
           ]

--- a/filters/test filter/readme.md
+++ b/filters/test filter/readme.md
@@ -70,6 +70,5 @@ referenced pages will be available in the site, however.
 
 -   [Syllabus](orga/syllabus.md)
 -   [Ressourcen](orga/resources.md)
--   [Note und Credits](orga/grading.md)
 -   [Prüfungsvorbereitung](orga/exams.md)
 :::

--- a/filters/test filter/subdir/file-d.md
+++ b/filters/test filter/subdir/file-d.md
@@ -1,3 +1,5 @@
 # Subdir/File-D.md
 
 Wuppie!
+
+[link to ../orga/grading](../orga/grading.md)


### PR DESCRIPTION
This changes will allow references to files up the directory structure, i.e. something like `[foo](../../foo.md)` should work now.

We use a little trick to achieve this behaviour: When evaluating a link, let Pandoc change the working directory to the link path. This will resolve all `../` (if possible) and we can then ask Pandoc for the current working directory (absolute path) and compare this to the absolute path to the project directory to get a relative path to our file ...