### PR TITLE
[Filter] add filter to include local Markdown file via Markdown links in paragraphs

### DIFF
--- a/filters/include-mdfiles.lua
+++ b/filters/include-mdfiles.lua
@@ -1,0 +1,118 @@
+--[[
+include-mdfiles.lua – filter to include local Markdown files via links
+
+for each link to local Markdown file in start document:
+    (1) read file
+    (2) "fix" links to local images, i.e. prepend include path
+    (3) process links to local Markdown files in paragraphs and include content (recursively)
+        - foreach Para:
+            - prepare new empty block list (result), add new current block (empty Para)
+            - foreach inline in current Para:
+                - if not link: append inline to current block's content
+                - if link:
+                    - read link.target (file), process content and append resulting blocks to block list
+                    - add new current block (empty Para) for remaining inlines of current block
+            - return block list to replace current Para
+]]--
+
+
+-- vars
+local ROOT = "."    -- absolute path to working directory when starting
+
+
+-- helper
+local function _is_relative (target)
+    return pandoc.path.is_relative(target)
+end
+
+local function _is_url (target)
+    return target:match('https?://.*')
+end
+
+local function _is_markdown (target)
+    return target:match('.*%.md')
+end
+
+local function _is_local_path (path)
+    return _is_relative(path) and
+           not _is_url(path)
+end
+
+local function _is_local_markdown_file_link (inline)
+    return inline and
+           inline.t and
+           inline.t == "Link" and
+           _is_markdown(inline.target) and
+           _is_local_path(inline.target)
+end
+
+local function _join_path (include_path, file)
+    return pandoc.path.normalize(pandoc.path.join({include_path, file}))
+end
+
+
+-- open file, read content, parse recursivly and return list of blocks
+local function _handle_file (lnk)
+    local fh = io.open(lnk, "r")
+    if not fh then
+        io.stderr:write("\t (_handle_file) cannot open file '" .. lnk .. "' ... skipping ... \n")
+        return pandoc.List:new()
+    else
+        local content = fh:read "*all"
+        fh:close()
+
+        return pandoc.system.with_working_directory(
+            pandoc.path.directory(lnk),    -- may still contain '../'
+            function ()
+                local wrkdir = pandoc.system.get_working_directory()    -- same as 'pandoc.path.directory(lnk)' but w/o '../' since Pandoc cd'ed here
+                return process_doc(
+                    pandoc.read(content, "markdown", PANDOC_READER_OPTIONS).blocks,
+                    pandoc.path.make_relative(wrkdir, ROOT))
+            end)
+    end
+end
+
+
+-- process Pandoc document (list of blocks): fix image sources (prepend include path), recursive include of links
+function process_doc (blocks, include_path)
+    return blocks:walk({
+        Image = function (img)
+            if _is_local_path(img.src) then
+                -- prepend current include path to image source
+                img.src = _join_path(include_path, img.src)
+                return img
+            end
+        end,
+        Para = function (bl)
+            local block_list = pandoc.List:new()
+            local current_block = pandoc.Para({})
+            block_list:insert(current_block)
+
+            for _,i in ipairs(bl.content) do
+                if _is_local_markdown_file_link(i) then
+                    -- process link target
+                    block_list:extend(_handle_file(i.target))
+
+                    -- "close" current block and open new one for any remaining inlines in current block 'bl'
+                    current_block = pandoc.Para({})
+                    block_list:insert(current_block)
+                else
+                    -- copy inline into block content
+                    current_block.content:insert(i)
+                end
+            end
+
+            return block_list
+        end
+    })
+end
+
+
+-- main filter function
+function Pandoc (doc)
+    -- remember our project root
+    ROOT = pandoc.system.get_working_directory()
+
+    -- process all images and links
+    return pandoc.Pandoc(process_doc(doc.blocks, "."), doc.meta)
+end

--- a/filters/test filter/Makefile
+++ b/filters/test filter/Makefile
@@ -3,12 +3,14 @@ PANDOC ?= pandoc
 
 FILES_TRANSFORM = readme.md
 FILES_MAKEDEPS  = readme.md
+FILES_INCLUDEMD = summary.md
 
 LUA_REWRITELINKS = ../hugo_rewritelinks.lua
 LUA_MAKEDEPS     = ../hugo_makedeps.lua
+LUA_INCLUDEMD    = ../include-mdfiles.lua
 
 
-test: test_rewritelinks test_makedeps
+test: test_rewritelinks test_makedeps test_includemd
 
 test_rewritelinks: $(FILES_TRANSFORM)
 	@$(PANDOC) -L $(LUA_REWRITELINKS) -t native $^                                        \
@@ -29,6 +31,10 @@ test_makedeps: $(FILES_MAKEDEPS)
 	    | $(DIFF) expected_makedeps3.native -
 	@$(PANDOC) -L $(LUA_MAKEDEPS) -M prefix="foobar" -M indexMD="readme" -t native $^     \
 	    | $(DIFF) expected_makedeps4.native -
+
+test_includemd: $(FILES_INCLUDEMD)
+	@$(PANDOC) -L $(LUA_INCLUDEMD) -t native $^                                           \
+	    | $(DIFF) expected_inludemd.native -
 
 
 expected: expected_rewritelinks1.native expected_rewritelinks2.native expected_rewritelinks3.native expected_rewritelinks4.native
@@ -51,9 +57,14 @@ expected_makedeps3.native: $(FILES_MAKEDEPS)
 expected_makedeps4.native: $(FILES_MAKEDEPS)
 	$(PANDOC) -L $(LUA_MAKEDEPS) -M prefix="foobar" -M indexMD="readme" -t native -o $@ $^
 
+expected: expected_inludemd.native
+expected_inludemd.native: $(FILES_INCLUDEMD)
+	$(PANDOC) -L $(LUA_INCLUDEMD) -t native -o $@ $^
+
 
 clean:
 	rm -rf expected_rewritelinks1.native expected_rewritelinks2.native expected_rewritelinks3.native expected_rewritelinks4.native
 	rm -rf expected_makedeps1.native expected_makedeps2.native expected_makedeps3.native expected_makedeps4.native
+	rm -rf expected_inludemd.native
 
-.PHONY: test test_rewritelinks test_makedeps expected clean
+.PHONY: test test_rewritelinks test_makedeps test_includemd expected clean

--- a/filters/test filter/expected_inludemd.native
+++ b/filters/test filter/expected_inludemd.native
@@ -1,0 +1,6718 @@
+[ Header 1 ( "summary.md" , [] , [] ) [ Str "Summary.md" ]
+, Header
+    2
+    ( "this-should-work" , [] , [] )
+    [ Str "This" , Space , Str "should" , Space , Str "work" ]
+, Para [ Str "Thanks" , Space , Str "everyone!" ]
+, HorizontalRule
+, Para []
+, Header 1 ( "file-a.md" , [] , [] ) [ Str "file-a.md" ]
+, Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Code ( "" , [] , [] ) "file-a.md"
+    , Str "."
+    ]
+, Para []
+, HorizontalRule
+, Figure
+    ( "" , [] , [] )
+    (Caption
+       Nothing
+       [ Plain
+           [ Str "Image"
+           , Space
+           , Str "A"
+           , Space
+           , Str "(from"
+           , Space
+           , Str "Readme.md)"
+           ]
+       ])
+    [ Plain
+        [ Image
+            ( "" , [] , [] )
+            [ Str "Image"
+            , Space
+            , Str "A"
+            , Space
+            , Str "(from"
+            , Space
+            , Str "Readme.md)"
+            ]
+            ( "img/a.png" , "" )
+        ]
+    ]
+, Para [ Image ( "" , [] , [] ) [] ( "img/a.png" , "" ) ]
+, Header
+    2
+    ( "different-wrong-format" , [] , [] )
+    [ Str "Different"
+    , Space
+    , Str "(wrong)"
+    , Space
+    , Str "format"
+    ]
+, BulletList
+    [ [ Plain
+          [ Link
+              ( "" , [] , [] )
+              [ Str "wrong" , Space , Str "extension" ]
+              ( "file-c.png" , "" )
+          ]
+      ]
+    , [ Plain
+          [ Link
+              ( "" , [] , [] )
+              [ Str "not" , Space , Str "local" ]
+              ( "https://pandoc.org/lua-filters.html" , "" )
+          ]
+      ]
+    , [ Plain
+          [ Link
+              ( "" , [] , [] )
+              [ Str "still" , Space , Str "not" , Space , Str "local" ]
+              ( "https://pandoc.org/lua-filters.md" , "" )
+          ]
+      ]
+    , [ Plain
+          [ Link
+              ( "" , [] , [] )
+              [ Str "also" , Space , Str "not" , Space , Str "local" ]
+              ( "http://pandoc.org/lua-filters.md" , "" )
+          ]
+      ]
+    , [ Plain
+          [ Link
+              ( "" , [] , [] )
+              [ Str "not"
+              , Space
+              , Str "there"
+              , Space
+              , Str "and"
+              , Space
+              , Str "not"
+              , Space
+              , Str "here"
+              ]
+              ( "wuppie.md" , "" )
+          ]
+      ]
+    ]
+, HorizontalRule
+, Para
+    [ Str "since"
+    , Space
+    , Str "our"
+    , Space
+    , Str "filter"
+    , Space
+    , Str "works"
+    , Space
+    , Str "for"
+    , Space
+    , Code ( "" , [] , [] ) "pandoc.Para"
+    , Space
+    , Str "only,"
+    , Space
+    , Str "let\8217s"
+    , Space
+    , Str "put"
+    , Space
+    , Str "these"
+    , Space
+    , Str "links"
+    , Space
+    , Str "into"
+    , Space
+    , Str "a"
+    , Space
+    , Str "paragraph:"
+    , SoftBreak
+    ]
+, Para
+    [ Space
+    , Str "and"
+    , Space
+    , Link
+        ( "" , [] , [] )
+        [ Str "still" , Space , Str "not" , Space , Str "local" ]
+        ( "https://pandoc.org/lua-filters.md" , "" )
+    , Str "."
+    ]
+, HorizontalRule
+, Header
+    2
+    ( "recursive-inclusion" , [] , [] )
+    [ Str "Recursive" , Space , Str "inclusion" ]
+, HorizontalRule
+, Para []
+, Header
+    1 ( "subdirfile-d.md" , [] , [] ) [ Str "Subdir/File-D.md" ]
+, Para [ Str "Wuppie!" ]
+, HorizontalRule
+, Para []
+, Header
+    2 ( "pr\252fungsform" , [] , [] ) [ Str "Pr\252fungsform" ]
+, Para
+    [ Strong
+        [ Str "Performanzpr\252fung,"
+        , Space
+        , Str "7"
+        , Space
+        , Str "ECTS"
+        ]
+    ]
+, BulletList
+    [ [ Para
+          [ Strong [ Str "Praktische" , Space , Str "Teilleistung" ]
+          , Str ":"
+          , SoftBreak
+          , Str "Regelm\228\223ige"
+          , Space
+          , Str "Bearbeitung"
+          , Space
+          , Str "der"
+          , Space
+          , Str "Praktikumsaufgaben,"
+          , SoftBreak
+          , Str "fristgerechte"
+          , Space
+          , Str "Abgabe"
+          , Space
+          , Str "der"
+          , Space
+          , Str "L\246sungen"
+          , Space
+          , Str "(PDF,"
+          , Space
+          , Str "ZIP,"
+          , Space
+          , Str "Link)"
+          , Space
+          , Str "im"
+          , Space
+          , Str "ILIAS,"
+          , SoftBreak
+          , Str "Erstellung"
+          , Space
+          , Str "von"
+          , Space
+          , Str "Peer-Feedback"
+          , Space
+          , Str "im"
+          , Space
+          , Str "ILIAS,"
+          , SoftBreak
+          , Str "Vorstellung"
+          , Space
+          , Str "der"
+          , Space
+          , Str "L\246sungen"
+          , Space
+          , Str "im"
+          , Space
+          , Str "Praktikum"
+          , Space
+          , Str "=>"
+          , Space
+          , Str "Punkte"
+          ]
+      , Para [ Str "Notenspiegel:" ]
+      , BulletList
+          [ [ Plain
+                [ Str "90"
+                , Space
+                , Str "Punkte"
+                , Space
+                , Str "gesamt"
+                , Space
+                , Str "erreichbar:"
+                , Space
+                , Str "Zyklus"
+                , Space
+                , Str "1"
+                , Space
+                , Str "und"
+                , Space
+                , Str "2"
+                , Space
+                , Str "je"
+                , Space
+                , Str "15"
+                , Space
+                , Str "Punkte,"
+                , Space
+                , Str "Zyklus"
+                , Space
+                , Str "3"
+                , Space
+                , Str "bis"
+                , Space
+                , Str "5"
+                , Space
+                , Str "je"
+                , Space
+                , Str "15+5"
+                , Space
+                , Str "Punkte"
+                ]
+            ]
+          , [ Plain
+                [ Str "4.0:"
+                , Space
+                , Str "ab"
+                , Space
+                , Str "50%"
+                , Space
+                , Str "(45.0"
+                , Space
+                , Str "Punkte),"
+                , Space
+                , Str "alle"
+                , Space
+                , Str "5%"
+                , Space
+                , Str "n\228chste"
+                , Space
+                , Str "Teilnote,"
+                , Space
+                , Str "1.0:"
+                , Space
+                , Str "ab"
+                , Space
+                , Str "95%"
+                , Space
+                , Str "(85.5"
+                , Space
+                , Str "Punkte)"
+                ]
+            ]
+          ]
+      ]
+    , [ Para
+          [ Strong [ Str "Theoretische" , Space , Str "Teilleistung" ]
+          , Str ":"
+          , SoftBreak
+          , Str "Digitale"
+          , Space
+          , Str "Klausur"
+          , Space
+          , Str "in"
+          , Space
+          , Str "den"
+          , Space
+          , Str "Pr\252fungszeitr\228umen"
+          ]
+      ]
+    , [ Para
+          [ Strong [ Str "Gesamtnote" ]
+          , Str ":"
+          , SoftBreak
+          , Str "50%"
+          , Space
+          , Str "Praxis,"
+          , Space
+          , Str "50%"
+          , Space
+          , Str "Theorie"
+          ]
+      ]
+    ]
+, Para
+    [ Str "Wiederholer"
+    , Space
+    , Str "mit"
+    , Space
+    , Str "bereits"
+    , Space
+    , Str "begonnener"
+    , Space
+    , Str "Parcours-Pr\252fung"
+    , Space
+    , Str "absolvieren"
+    , Space
+    , Str "stattdessen"
+    , Space
+    , Str "eine"
+    , Space
+    , Str "Parcours-Pr\252fung."
+    , SoftBreak
+    , Str "Bitte"
+    , Space
+    , Str "melden"
+    , Space
+    , Str "Sie"
+    , Space
+    , Str "sich"
+    , Space
+    , Str "vor"
+    , Space
+    , Str "Beginn"
+    , Space
+    , Str "der"
+    , Space
+    , Str "Praktika"
+    , Space
+    , Str "per"
+    , Space
+    , Str "E-Mail"
+    , Space
+    , Str "beim"
+    , Space
+    , Str "Dozenten."
+    ]
+, Header
+    2
+    ( "hinweise-zum-praktikum-praktische-teilleistung"
+    , []
+    , []
+    )
+    [ Str "Hinweise"
+    , Space
+    , Str "zum"
+    , Space
+    , Str "Praktikum"
+    , Space
+    , Str "(praktische"
+    , Space
+    , Str "Teilleistung)"
+    ]
+, Header
+    3
+    ( "bearbeitung-der-aufgaben" , [] , [] )
+    [ Str "Bearbeitung"
+    , Space
+    , Str "der"
+    , Space
+    , Str "Aufgaben"
+    ]
+, Para
+    [ Str "Sie"
+    , Space
+    , Str "bearbeiten"
+    , Space
+    , Str "alle"
+    , Space
+    , Str "Aufgaben"
+    , Space
+    , Str "in"
+    , Space
+    , Str "festen"
+    , Space
+    , Str "Teams"
+    , Space
+    , Str "zu"
+    , Space
+    , Str "je"
+    , Space
+    , Strong [ Str "drei" , Space , Str "Personen" ]
+    , Str "."
+    , Space
+    , Str "Jedes"
+    , Space
+    , Str "Team"
+    , Space
+    , Str "erarbeitet"
+    , Space
+    , Str "seine"
+    , SoftBreak
+    , Strong [ Str "eigene" ]
+    , Space
+    , Str "L\246sung."
+    ]
+, Para
+    [ Str "Wer"
+    , Space
+    , Str "L\246sungen"
+    , Space
+    , Str "ganz"
+    , Space
+    , Str "oder"
+    , Space
+    , Str "teilweise"
+    , Space
+    , Str "von"
+    , Space
+    , Str "anderen"
+    , Space
+    , Str "Teams/Studierenden"
+    , Space
+    , Str "oder"
+    , Space
+    , Str "anderen"
+    , Space
+    , Str "Quellen"
+    , Space
+    , Str "\252bernimmt"
+    , SoftBreak
+    , Str "und"
+    , Space
+    , Str "als"
+    , Space
+    , Str "eigene"
+    , Space
+    , Str "L\246sung"
+    , Space
+    , Str "ab-/ausgibt,"
+    , Space
+    , Str "begeht"
+    , Space
+    , Str "einen"
+    , Space
+    , Str "T\228uschungsversuch"
+    , Space
+    , Str "mit"
+    , Space
+    , Str "entsprechenden"
+    , Space
+    , Str "Konsequenzen"
+    , SoftBreak
+    , Str "im"
+    , Space
+    , Str "Pr\252fungsverfahren."
+    ]
+, Header
+    3 ( "wochen-zyklen" , [] , [] ) [ Str "2-Wochen-Zyklen" ]
+, Para
+    [ Str "Das"
+    , Space
+    , Str "Praktikum"
+    , Space
+    , Str "erfolgt"
+    , Space
+    , Str "in"
+    , Space
+    , Str "2-Wochen-Zyklen:"
+    ]
+, OrderedList
+    ( 1 , Decimal , Period )
+    [ [ Plain
+          [ Str "Erste"
+          , Space
+          , Str "Zyklus-Woche:"
+          , Space
+          , Str "Konzeptphase"
+          ]
+      , BulletList
+          [ [ Plain
+                [ Str "Auswahl"
+                , Space
+                , Str "der"
+                , Space
+                , Str "zu"
+                , Space
+                , Str "bearbeitenden"
+                , Space
+                , Str "Aufgaben"
+                , Space
+                , Str "(=>"
+                , Space
+                , Str "Team)"
+                ]
+            ]
+          , [ Plain
+                [ Str "Erstellung"
+                , Space
+                , Str "einer"
+                , Space
+                , Str "Konzeptskizze"
+                , Space
+                , Str "(PDF)"
+                , Space
+                , Str "(=>"
+                , Space
+                , Str "Team)"
+                ]
+            ]
+          , [ Plain
+                [ Str "Abgabe"
+                , Space
+                , Str "der"
+                , Space
+                , Str "Konzeptskizze"
+                , Space
+                , Str "(PDF)"
+                , Space
+                , Str "im"
+                , Space
+                , Str "ILIAS"
+                , Space
+                , Str "(=>"
+                , Space
+                , Str "Jede(r)"
+                , Space
+                , Str "einzeln)"
+                ]
+            ]
+          , [ Plain
+                [ Str "Peer-Feedback"
+                , Space
+                , Str "zur"
+                , Space
+                , Str "Konzeptskizze"
+                , Space
+                , Str "im"
+                , Space
+                , Str "ILIAS"
+                , Space
+                , Str "(=>"
+                , Space
+                , Str "Jede(r)"
+                , Space
+                , Str "einzeln)"
+                ]
+            ]
+          , [ Plain
+                [ Str "Vorstellung"
+                , Space
+                , Str "der"
+                , Space
+                , Str "Konzeptskizze"
+                , Space
+                , Str "im"
+                , Space
+                , Str "Praktikum"
+                , Space
+                , Str "(=>"
+                , Space
+                , Str "Team)"
+                ]
+            ]
+          ]
+      ]
+    , [ Plain
+          [ Str "Zweite"
+          , Space
+          , Str "Zyklus-Woche:"
+          , Space
+          , Str "Implementierungsphase"
+          ]
+      , BulletList
+          [ [ Plain
+                [ Str "Umsetzung"
+                , Space
+                , Str "des"
+                , Space
+                , Str "Konzepts/Implementierung"
+                , Space
+                , Str "der"
+                , Space
+                , Str "L\246sung"
+                , Space
+                , Str "(=>"
+                , Space
+                , Str "Team)"
+                ]
+            ]
+          , [ Plain
+                [ Str "Abgabe"
+                , Space
+                , Str "des"
+                , Space
+                , Str "Quellcodes"
+                , Space
+                , Str "(ZIP"
+                , Space
+                , Str "bzw."
+                , Space
+                , Str "Link)"
+                , Space
+                , Str "im"
+                , Space
+                , Str "ILIAS"
+                , Space
+                , Str "(=>"
+                , Space
+                , Str "Jede(r)"
+                , Space
+                , Str "einzeln)"
+                ]
+            ]
+          , [ Plain
+                [ Str "Peer-Feedback"
+                , Space
+                , Str "zum"
+                , Space
+                , Str "Quellcode"
+                , Space
+                , Str "im"
+                , Space
+                , Str "ILIAS"
+                , Space
+                , Str "(=>"
+                , Space
+                , Str "Jede(r)"
+                , Space
+                , Str "einzeln)"
+                ]
+            ]
+          , [ Plain
+                [ Str "Vorstellung"
+                , Space
+                , Str "des"
+                , Space
+                , Str "Quellcodes"
+                , Space
+                , Str "im"
+                , Space
+                , Str "Praktikum"
+                , Space
+                , Str "(=>"
+                , Space
+                , Str "Team)"
+                ]
+            ]
+          ]
+      ]
+    ]
+, Para
+    [ Str "Sie"
+    , Space
+    , Str "k\246nnen"
+    , Space
+    , Str "pro"
+    , Space
+    , Str "Zyklus"
+    , Space
+    , Str "Aufgaben"
+    , Space
+    , Str "im"
+    , Space
+    , Str "Umfang"
+    , Space
+    , Str "von"
+    , Space
+    , Str "15"
+    , Space
+    , Str "Punkten"
+    , Space
+    , Str "abgeben/vorstellen."
+    ]
+, Header
+    3 ( "punktevergabe" , [] , [] ) [ Str "Punktevergabe" ]
+, Para
+    [ Str "F\252r"
+    , Space
+    , Str "die"
+    , Space
+    , Str "Vergabe"
+    , Space
+    , Str "der"
+    , Space
+    , Str "Punkte"
+    , Space
+    , Str "m\252ssen"
+    , Space
+    , Str "Sie"
+    , Space
+    , Str "pro"
+    , Space
+    , Str "Zyklus"
+    , Space
+    , Str "jeweils"
+    , Space
+    , Str "fristgerecht"
+    , SoftBreak
+    , Str "Ihre"
+    , Space
+    , Str "Konzeptskizze"
+    , Space
+    , Str "als"
+    , Space
+    , Str "PDF"
+    , Space
+    , Str "eingereicht"
+    , Space
+    , Str "und"
+    , Space
+    , Str "im"
+    , Space
+    , Str "Praktikum"
+    , Space
+    , Str "vorgestellt"
+    , Space
+    , Str "haben,"
+    , SoftBreak
+    , Str "in"
+    , Space
+    , Str "beiden"
+    , Space
+    , Str "Zyklen-H\228lften"
+    , Space
+    , Str "das"
+    , Space
+    , Str "Peer-Feedback"
+    , Space
+    , Str "erstellt"
+    , Space
+    , Str "haben"
+    , Space
+    , Str "und"
+    , SoftBreak
+    , Str "die"
+    , Space
+    , Str "L\246sung"
+    , Space
+    , Str "(Quellcode:"
+    , Space
+    , Str "Abgabe"
+    , Space
+    , Str "per"
+    , Space
+    , Str "ZIP"
+    , Space
+    , Str "oder"
+    , Space
+    , Str "Link,"
+    , Space
+    , Str "vgl."
+    , Space
+    , Str "Anweisungen"
+    , Space
+    , Str "auf"
+    , Space
+    , Str "den"
+    , SoftBreak
+    , Str "\220bungsbl\228ttern)"
+    , Space
+    , Str "eingereicht"
+    , Space
+    , Str "und"
+    , Space
+    , Str "im"
+    , Space
+    , Str "Praktikum"
+    , Space
+    , Str "vorgestellt"
+    , Space
+    , Str "haben."
+    ]
+, Header
+    3
+    ( "sonderabgabe-letzte-vorlesungswoche" , [] , [] )
+    [ Str "Sonderabgabe"
+    , Space
+    , Str "letzte"
+    , Space
+    , Str "Vorlesungswoche"
+    ]
+, Para
+    [ Str "Zusatztermin"
+    , Space
+    , Str "f\252r"
+    , Space
+    , Str "Studierende,"
+    , Space
+    , Str "die"
+    , Space
+    , Str "bis"
+    , Space
+    , Str "dahin"
+    , Space
+    , Str "unterhalb"
+    , Space
+    , Str "der"
+    , Space
+    , Str "Bestehensschwelle"
+    , Space
+    , Str "f\252r"
+    , Space
+    , Str "die"
+    , Space
+    , Str "praktische"
+    , SoftBreak
+    , Str "Teilleistung"
+    , Space
+    , Str "liegen"
+    , Space
+    , Str "oder"
+    , Space
+    , Str "die"
+    , Space
+    , Str "wegen"
+    , Space
+    , Str "Krankheit"
+    , Space
+    , Str "einen"
+    , Space
+    , Str "Termin"
+    , Space
+    , Str "nicht"
+    , Space
+    , Str "wahrnehmen"
+    , Space
+    , Str "konnten."
+    ]
+, Para
+    [ Str "F\252r"
+    , Space
+    , Str "diese"
+    , Space
+    , Str "Abgabe"
+    , Space
+    , Str "gibt"
+    , Space
+    , Str "es"
+    , Space
+    , Str "keine"
+    , Space
+    , Str "Konzeptphase"
+    , Space
+    , Str "und"
+    , Space
+    , Str "auch"
+    , Space
+    , Str "kein"
+    , Space
+    , Str "Peer-Feedback,"
+    , Space
+    , Str "die"
+    , Space
+    , Str "L\246sung"
+    , Space
+    , Str "(Link)"
+    , SoftBreak
+    , Str "ist"
+    , Space
+    , Str "bis"
+    , Space
+    , Str "zur"
+    , Space
+    , Str "Deadline"
+    , Space
+    , Str "im"
+    , Space
+    , Str "ILIAS"
+    , Space
+    , Str "hochzuladen"
+    , Space
+    , Str "und"
+    , Space
+    , Str "im"
+    , Space
+    , Str "nachfolgenden"
+    , Space
+    , Str "Praktikum"
+    , Space
+    , Str "vorzustellen."
+    ]
+, Header
+    2
+    ( "hinweise-zur-klausur-theoretische-teilleistung"
+    , []
+    , []
+    )
+    [ Str "Hinweise"
+    , Space
+    , Str "zur"
+    , Space
+    , Str "Klausur"
+    , Space
+    , Str "(theoretische"
+    , Space
+    , Str "Teilleistung)"
+    ]
+, Para
+    [ Str "Pr\252fung"
+    , Space
+    , Str "Theorie"
+    , Space
+    , Str "(Termin"
+    , Space
+    , Str "1):"
+    , Space
+    , Str "Die"
+    , Space
+    , Str "Pr\252fung"
+    , Space
+    , Str "zum"
+    , Space
+    , Str "theoretischen"
+    , Space
+    , Str "Teil"
+    , Space
+    , Str "findet"
+    , Space
+    , Str "am"
+    , Space
+    , Str "Mittwoch,"
+    , Space
+    , Str "05.07.23,"
+    , SoftBreak
+    , Str "im"
+    , Space
+    , Str "B40"
+    , Space
+    , Str "am"
+    , Space
+    , Str "Campus"
+    , Space
+    , Str "Minden"
+    , Space
+    , Str "als"
+    , Space
+    , Str "digitale"
+    , Space
+    , Str "Klausur"
+    , Space
+    , Str "auf"
+    , Space
+    , Str "dem"
+    , Space
+    , Str "HSBI-Pr\252fungs-ILIAS"
+    , Space
+    , Str "statt."
+    ]
+, Para
+    [ Str "Da"
+    , Space
+    , Str "in"
+    , Space
+    , Str "diesem"
+    , Space
+    , Str "Raum"
+    , Space
+    , Str "nur"
+    , Space
+    , Str "30"
+    , Space
+    , Str "Personen"
+    , Space
+    , Str "gleichzeitig"
+    , Space
+    , Str "gepr\252ft"
+    , Space
+    , Str "werden"
+    , Space
+    , Str "k\246nnen,"
+    , Space
+    , Str "werden"
+    , Space
+    , Str "wir"
+    , Space
+    , Str "in"
+    , Space
+    , Str "zwei"
+    , SoftBreak
+    , Str "Durchl\228ufen"
+    , Space
+    , Str "arbeiten:"
+    , Space
+    , Str "09:00-10:30"
+    , Space
+    , Str "Uhr"
+    , Space
+    , Str "und"
+    , Space
+    , Str "11:00-12:30"
+    , Space
+    , Str "Uhr."
+    , Space
+    , Str "Sie"
+    , Space
+    , Str "k\246nnen"
+    , Space
+    , Str "nur"
+    , Space
+    , Str "an"
+    , Space
+    , Str "einer"
+    , Space
+    , Str "der"
+    , Space
+    , Str "beiden"
+    , SoftBreak
+    , Str "Sitzungen"
+    , Space
+    , Str "teilnehmen."
+    ]
+, Para
+    [ Str "Es"
+    , Space
+    , Str "gibt"
+    , Space
+    , Str "entsprechend"
+    , Space
+    , Str "zwei"
+    , Space
+    , Str "Eintr\228ge"
+    , Space
+    , Str "im"
+    , Space
+    , Str "Pr\252fungs-ILIAS."
+    , Space
+    , Str "Die"
+    , Space
+    , Str "Zugangsdaten"
+    , Space
+    , Str "wurden"
+    , Space
+    , Str "an"
+    , Space
+    , Str "alle"
+    , Space
+    , Str "im"
+    , Space
+    , Str "LSF"
+    , SoftBreak
+    , Str "f\252r"
+    , Space
+    , Str "die"
+    , Space
+    , Str "Pr\252fung"
+    , Space
+    , Str "angemeldeten"
+    , Space
+    , Str "Studierenden"
+    , Space
+    , Str "geschickt."
+    , Space
+    , Str "Bitte"
+    , Space
+    , Str "melden"
+    , Space
+    , Str "Sie"
+    , Space
+    , Str "sich"
+    , Space
+    , Str "bis"
+    , Space
+    , Str "Freitag,"
+    , SoftBreak
+    , Str "30.06.23,"
+    , Space
+    , Str "in"
+    , Space
+    , Str "einem"
+    , Space
+    , Str "der"
+    , Space
+    , Str "beiden"
+    , Space
+    , Str "Pr\252fungskursr\228ume"
+    , Space
+    , Str "an"
+    , Space
+    , Str "("
+    , Quoted
+        DoubleQuote
+        [ Str "Beitritt"
+        , Space
+        , Str "mit"
+        , Space
+        , Str "Best\228tigung"
+        ]
+    , Str ")."
+    , Space
+    , Str "Beachten"
+    , Space
+    , Str "Sie"
+    , SoftBreak
+    , Str "die"
+    , Space
+    , Str "Gruppengr\246\223e,"
+    , Space
+    , Str "es"
+    , Space
+    , Str "k\246nnen"
+    , Space
+    , Str "sich"
+    , Space
+    , Str "max."
+    , Space
+    , Str "30"
+    , Space
+    , Str "Personen"
+    , Space
+    , Str "pro"
+    , Space
+    , Str "Durchlauf"
+    , Space
+    , Str "anmelden."
+    , Space
+    , Str "Es"
+    , Space
+    , Str "gibt"
+    , Space
+    , Str "keine"
+    , SoftBreak
+    , Str "Wartelisten"
+    , Space
+    , Str "-"
+    , Space
+    , Str "wenn"
+    , Space
+    , Str "einer"
+    , Space
+    , Str "der"
+    , Space
+    , Str "beiden"
+    , Space
+    , Str "Pr\252fungskursr\228ume"
+    , Space
+    , Str "voll"
+    , Space
+    , Str "ist,"
+    , Space
+    , Str "melden"
+    , Space
+    , Str "Sie"
+    , Space
+    , Str "sich"
+    , Space
+    , Str "bitte"
+    , Space
+    , Str "beim"
+    , SoftBreak
+    , Str "anderen"
+    , Space
+    , Str "Pr\252fungskursraum"
+    , Space
+    , Str "an."
+    ]
+, Para
+    [ Str "Sie"
+    , Space
+    , Str "ben\246tigen"
+    , Space
+    , Str "am"
+    , Space
+    , Str "Pr\252fungstag"
+    , Space
+    , Str "Ihre"
+    , Space
+    , Str "HSBI-Zugangsdaten"
+    , Space
+    , Str "(User,"
+    , Space
+    , Str "Passwort),"
+    , Space
+    , Str "einen"
+    , Space
+    , Str "Studierendenausweis"
+    , SoftBreak
+    , Str "und"
+    , Space
+    , Str "Personalausweis"
+    , Space
+    , Str "sowie"
+    , Space
+    , Str "Ihren"
+    , Space
+    , Str "DIN-A4-Spickzettel."
+    ]
+, Para
+    [ Str "Pr\252fungsrelevant"
+    , Space
+    , Str "sind"
+    , Space
+    , Str "die"
+    , Space
+    , Str "im"
+    , Space
+    , Quoted DoubleQuote [ Str "Fahrplan" ]
+    , Space
+    , Str "verlinkten"
+    , Space
+    , Str "Inhalte."
+    ]
+, Para []
+, HorizontalRule
+, Para []
+, HorizontalRule
+, Para []
+, Para
+    [ RawInline
+        (Format "markdown") "{{< children showhidden=\"true\" >}}"
+    ]
+, Figure
+    ( "" , [] , [] )
+    (Caption
+       Nothing
+       [ Plain
+           [ Str "This"
+           , Space
+           , Str "is"
+           , Space
+           , Str "Figure"
+           , Space
+           , Str "B"
+           , Space
+           , Str "(via"
+           , Space
+           , Str "Markdown)"
+           ]
+       ])
+    [ Plain
+        [ Image
+            ( "" , [] , [] )
+            [ Str "This"
+            , Space
+            , Str "is"
+            , Space
+            , Str "Figure"
+            , Space
+            , Str "B"
+            , Space
+            , Str "(via"
+            , Space
+            , Str "Markdown)"
+            ]
+            ( "subdir/leaf/img/b.png" , "" )
+        ]
+    ]
+, Para []
+, HorizontalRule
+, Div
+    ( "" , [ "slides" ] , [] )
+    [ Header
+        2
+        ( "hidden-parts" , [] , [] )
+        [ Str "Hidden" , Space , Str "Parts" ]
+    , Para
+        [ Str "This"
+        , Space
+        , Str "part"
+        , Space
+        , Str "will"
+        , Space
+        , Str "be"
+        , Space
+        , Str "visible"
+        , Space
+        , Str "while"
+        , Space
+        , Str "building"
+        , Space
+        , Str "the"
+        , Space
+        , Str "makefile"
+        , Space
+        , Str "dependencies,"
+        , Space
+        , Str "but"
+        , Space
+        , Str "will"
+        , Space
+        , Str "be"
+        , Space
+        , Str "removed"
+        , Space
+        , Str "for"
+        , Space
+        , Str "building"
+        , SoftBreak
+        , Str "the"
+        , Space
+        , Str "website"
+        , Space
+        , Str "because"
+        , Space
+        , Str "of"
+        , Space
+        , Str "being"
+        , Space
+        , Str "marked"
+        , Space
+        , Str "as"
+        , Space
+        , Str "slides"
+        , Space
+        , Str "content."
+        , Space
+        , Str "We"
+        , Space
+        , Str "can"
+        , Space
+        , Str "use"
+        , Space
+        , Str "this"
+        , Space
+        , Str "to"
+        , Space
+        , Str "include"
+        , Space
+        , Str "files"
+        , Space
+        , Str "in"
+        , Space
+        , Str "the"
+        , Space
+        , Str "build"
+        , SoftBreak
+        , Str "process"
+        , Space
+        , Str "even"
+        , Space
+        , Str "if"
+        , Space
+        , Str "we"
+        , Space
+        , Str "do"
+        , Space
+        , Str "not"
+        , Space
+        , Str "want"
+        , Space
+        , Str "to"
+        , Space
+        , Str "have"
+        , Space
+        , Str "explicit"
+        , Space
+        , Str "links"
+        , Space
+        , Str "in"
+        , Space
+        , Str "the"
+        , Space
+        , Str "site"
+        , Space
+        , Str "\8230"
+        ]
+    , Para
+        [ Str "Use"
+        , Space
+        , Str "case:"
+        , Space
+        , Str "We"
+        , Space
+        , Str "want"
+        , Space
+        , Str "to"
+        , Space
+        , Str "use"
+        , Space
+        , Str "a"
+        , Space
+        , Str "Hugo-generated"
+        , Space
+        , Str "schedule,"
+        , Space
+        , Str "i.e.\160we"
+        , Space
+        , Str "do"
+        , Space
+        , Str "not"
+        , Space
+        , Str "provide"
+        , Space
+        , Str "links"
+        , Space
+        , Str "to"
+        , Space
+        , Str "all"
+        , Space
+        , Str "individual"
+        , SoftBreak
+        , Str "lections"
+        , Space
+        , Str "in"
+        , Space
+        , Str "this"
+        , Space
+        , Str "readme"
+        , Space
+        , Str "or"
+        , Space
+        , Str "elsewhere,"
+        , Space
+        , Str "but"
+        , Space
+        , Str "need"
+        , Space
+        , Str "to"
+        , Space
+        , Str "define"
+        , Space
+        , Str "the"
+        , Space
+        , Str "scope"
+        , Space
+        , Str "of"
+        , Space
+        , Str "the"
+        , Space
+        , Str "semester/offering."
+        , Space
+        , Str "So"
+        , Space
+        , Str "all"
+        , SoftBreak
+        , Str "links"
+        , Space
+        , Str "to"
+        , Space
+        , Str "the"
+        , Space
+        , Str "lectures"
+        , Space
+        , Str "to"
+        , Space
+        , Str "be"
+        , Space
+        , Str "included"
+        , Space
+        , Str "can"
+        , Space
+        , Str "go"
+        , Space
+        , Str "here"
+        , Space
+        , Str "and"
+        , Space
+        , Str "will"
+        , Space
+        , Str "be"
+        , Space
+        , Str "hidden"
+        , Space
+        , Str "in"
+        , Space
+        , Str "the"
+        , Space
+        , Str "generated"
+        , Space
+        , Str "website."
+        , Space
+        , Str "The"
+        , SoftBreak
+        , Str "referenced"
+        , Space
+        , Str "pages"
+        , Space
+        , Str "will"
+        , Space
+        , Str "be"
+        , Space
+        , Str "available"
+        , Space
+        , Str "in"
+        , Space
+        , Str "the"
+        , Space
+        , Str "site,"
+        , Space
+        , Str "however."
+        ]
+    , Para
+        [ Str "This"
+        , Space
+        , Str "itemize"
+        , Space
+        , Str "will"
+        , Space
+        , Str "not"
+        , Space
+        , Str "be"
+        , Space
+        , Str "recognized"
+        , Space
+        , Str "and"
+        , Space
+        , Str "included:"
+        ]
+    , BulletList
+        [ [ Plain
+              [ Link
+                  ( "" , [] , [] )
+                  [ Str "Syllabus" ]
+                  ( "orga/syllabus.md" , "" )
+              ]
+          ]
+        , [ Plain
+              [ Link
+                  ( "" , [] , [] )
+                  [ Str "Ressourcen" ]
+                  ( "orga/resources.md" , "" )
+              ]
+          ]
+        , [ Plain
+              [ Link
+                  ( "" , [] , [] )
+                  [ Str "Pr\252fungsvorbereitung" ]
+                  ( "orga/exams.md" , "" )
+              ]
+          ]
+        ]
+    , Para
+        [ Str "But"
+        , Space
+        , Str "this"
+        , Space
+        , Str "will"
+        , Space
+        , Str "because"
+        , Space
+        , Str "of"
+        , Space
+        , Str "the"
+        , Space
+        , Str "new"
+        , Space
+        , Str "lines"
+        , Space
+        , Str "between"
+        , Space
+        , Str "each"
+        , Space
+        , Str "item:"
+        ]
+    , BulletList
+        [ [ Para []
+          , Header
+              2
+              ( "worum-gehts-hier" , [] , [] )
+              [ Str "Worum"
+              , Space
+              , Str "geht\8217s"
+              , Space
+              , Str "hier?"
+              ]
+          , Div
+              ( "" , [ "center" ] , [] )
+              [ Para
+                  [ Span
+                      ( "" , [ "alert" ] , [] )
+                      [ Strong
+                          [ Str "Weniger"
+                          , Space
+                          , Str "schlecht"
+                          , Space
+                          , Str "programmieren"
+                          ]
+                      ]
+                  , Space
+                  , RawInline (Format "tex") "\\quad "
+                  , Str ";-)"
+                  ]
+              ]
+          , BlockQuote
+              [ Para
+                  [ Str "\8230"
+                  , Space
+                  , Str "And,"
+                  , Space
+                  , Str "lastly,"
+                  , Space
+                  , Str "there\8217s"
+                  , Space
+                  , Str "the"
+                  , Space
+                  , Str "explosive"
+                  , Space
+                  , Str "growth"
+                  , Space
+                  , Str "in"
+                  , Space
+                  , Str "demand,"
+                  , Space
+                  , Str "which"
+                  , Space
+                  , Str "has"
+                  , Space
+                  , Str "led"
+                  , Space
+                  , Str "to"
+                  , Space
+                  , Str "many"
+                  , SoftBreak
+                  , Str "people"
+                  , Space
+                  , Str "doing"
+                  , Space
+                  , Str "it"
+                  , Space
+                  , Str "who"
+                  , Space
+                  , Str "aren\8217t"
+                  , Space
+                  , Str "any"
+                  , Space
+                  , Str "good"
+                  , Space
+                  , Str "at"
+                  , Space
+                  , Str "it."
+                  , Space
+                  , Str "Code"
+                  , Space
+                  , Str "is"
+                  , Space
+                  , Str "merely"
+                  , Space
+                  , Str "a"
+                  , Space
+                  , Str "means"
+                  , Space
+                  , Str "to"
+                  , Space
+                  , Str "an"
+                  , Space
+                  , Str "end."
+                  , SoftBreak
+                  , Strong
+                      [ Str "Programming"
+                      , Space
+                      , Str "is"
+                      , Space
+                      , Str "an"
+                      , Space
+                      , Str "art"
+                      , Space
+                      , Str "and"
+                      , Space
+                      , Str "code"
+                      , Space
+                      , Str "is"
+                      , Space
+                      , Str "merely"
+                      , Space
+                      , Str "its"
+                      , Space
+                      , Str "medium."
+                      ]
+                  , SoftBreak
+                  , Str "Pointing"
+                  , Space
+                  , Str "a"
+                  , Space
+                  , Str "camera"
+                  , Space
+                  , Str "at"
+                  , Space
+                  , Str "a"
+                  , Space
+                  , Str "subject"
+                  , Space
+                  , Str "does"
+                  , Space
+                  , Str "not"
+                  , Space
+                  , Str "make"
+                  , Space
+                  , Str "one"
+                  , Space
+                  , Str "a"
+                  , Space
+                  , Str "proper"
+                  , Space
+                  , Str "photographer."
+                  , Space
+                  , Str "There"
+                  , Space
+                  , Str "are"
+                  , SoftBreak
+                  , Str "a"
+                  , Space
+                  , Str "lot"
+                  , Space
+                  , Str "of"
+                  , Space
+                  , Str "self-described"
+                  , Space
+                  , Str "coders"
+                  , Space
+                  , Str "out"
+                  , Space
+                  , Str "there"
+                  , Space
+                  , Str "who"
+                  , Space
+                  , Str "couldn\8217t"
+                  , Space
+                  , Str "program"
+                  , Space
+                  , Str "their"
+                  , Space
+                  , Str "way"
+                  , Space
+                  , Str "out"
+                  , Space
+                  , Str "of"
+                  , Space
+                  , Str "a"
+                  , SoftBreak
+                  , Str "paper"
+                  , Space
+                  , Str "bag."
+                  ]
+              , Para
+                  [ RawInline (Format "tex") "\\hfill "
+                  , Str "\8211"
+                  , Space
+                  , Str "John"
+                  , Space
+                  , Str "Gruber"
+                  , Space
+                  , Str "auf"
+                  , Space
+                  , Link
+                      ( "" , [] , [] )
+                      [ Str "daringfireball.net" ]
+                      ( "https://daringfireball.net/2020/04/cobol_programming_coding"
+                      , ""
+                      )
+                  ]
+              ]
+          , Para
+              [ Str "Sie"
+              , Space
+              , Str "haben"
+              , Space
+              , Str "letztes"
+              , Space
+              , Str "Semester"
+              , Space
+              , Str "in"
+              , Space
+              , Str "OOP"
+              , Space
+              , Str "die"
+              , Space
+              , Emph [ Str "wichtigsten" ]
+              , Space
+              , Str "Elemente"
+              , Space
+              , Str "und"
+              , Space
+              , Str "Konzepte"
+              , Space
+              , Str "der"
+              , SoftBreak
+              , Str "Programmiersprache"
+              , Space
+              , Str "Java"
+              , Space
+              , Str "kennen"
+              , Space
+              , Str "gelernt."
+              ]
+          , Para
+              [ Str "Java"
+              , Space
+              , Str "ist"
+              , Space
+              , Str "neben"
+              , Space
+              , Str "C"
+              , Space
+              , Str "und"
+              , Space
+              , Str "Python"
+              , Space
+              , Str "derzeit"
+              , Space
+              , Str "die"
+              , Space
+              , Str "wichtigste"
+              , Space
+              , Str "Programmiersprache"
+              , Space
+              , Str "am"
+              , Space
+              , Str "Markt"
+              , SoftBreak
+              , Str "(siehe"
+              , Space
+              , Link
+                  ( "" , [] , [] )
+                  [ Str "TIOBE" , Space , Str "Index" ]
+                  ( "https://www.tiobe.com/tiobe-index/" , "" )
+              , Str ")."
+              ]
+          , Para
+              [ Str "Jetzt"
+              , Space
+              , Str "geht"
+              , Space
+              , Str "es"
+              , Space
+              , Str "darum,"
+              , Space
+              , Str "diese"
+              , Space
+              , Str "Kenntnisse"
+              , Space
+              , Str "sowohl"
+              , Space
+              , Str "auf"
+              , Space
+              , Str "der"
+              , Space
+              , Str "Java-"
+              , Space
+              , Str "als"
+              , Space
+              , Str "auch"
+              , Space
+              , Str "auf"
+              , Space
+              , Str "der"
+              , SoftBreak
+              , Str "Methoden-Seite"
+              , Space
+              , Str "so"
+              , Space
+              , Str "zu"
+              , Space
+              , Str "erweitern,"
+              , Space
+              , Str "dass"
+              , Space
+              , Str "Sie"
+              , Space
+              , Str "gemeinsam"
+              , Space
+              , Str "gr\246\223ere"
+              , Space
+              , Str "Anwendungen"
+              , Space
+              , Str "erstellen"
+              , SoftBreak
+              , Str "und"
+              , Space
+              , Str "pflegen"
+              , Space
+              , Str "k\246nnen:"
+              ]
+          , BulletList
+              [ [ Plain [ Strong [ Str "Java" ] ]
+                , BulletList
+                    [ [ Plain
+                          [ Str "Sich"
+                          , Space
+                          , Str "sicherer"
+                          , Space
+                          , Str "in"
+                          , Space
+                          , Str "Java"
+                          , Space
+                          , Str "bewegen:"
+                          , Space
+                          , Str "Praxiserfahrung"
+                          , Space
+                          , Str "und"
+                          , Space
+                          , Str "Routine"
+                          , Space
+                          , Str "gewinnen"
+                          ]
+                      ]
+                    , [ Plain
+                          [ Str "Wichtigste"
+                          , Space
+                          , Str "Konzepte"
+                          , Space
+                          , Str "und"
+                          , Space
+                          , Str "APIs"
+                          , Space
+                          , Str "kennen"
+                          , Space
+                          , Str "und"
+                          , Space
+                          , Str "beherrschen"
+                          ]
+                      ]
+                    , [ Plain
+                          [ Str "Merkmale"
+                          , Space
+                          , Str "gr\246\223erer"
+                          , Space
+                          , Str "Applikationen"
+                          , Space
+                          , Str "wie"
+                          , Space
+                          , Str "Logging"
+                          , Space
+                          , Str "und"
+                          , Space
+                          , Str "Konfiguration"
+                          , Space
+                          , Str "einsetzen"
+                          ]
+                      ]
+                    ]
+                ]
+              ]
+          , RawBlock (Format "tex") "\\smallskip"
+          , BulletList
+              [ [ Plain [ Strong [ Str "Design" ] ]
+                , BulletList
+                    [ [ Plain
+                          [ Str "Basis-Entwurfsmuster"
+                          , Space
+                          , Str "(er-)kennen"
+                          , Space
+                          , Str "und"
+                          , Space
+                          , Str "einsetzen"
+                          ]
+                      ]
+                    ]
+                ]
+              ]
+          , RawBlock (Format "tex") "\\smallskip"
+          , BulletList
+              [ [ Plain [ Strong [ Str "Methoden" ] ]
+                , BulletList
+                    [ [ Plain
+                          [ Str "Code"
+                          , Space
+                          , Str "erstellen"
+                          , Space
+                          , Str "und"
+                          , Space
+                          , Str "pflegen"
+                          , Space
+                          , Str "wie"
+                          , Space
+                          , Str "die"
+                          , Space
+                          , Str "Profis"
+                          ]
+                      , BulletList
+                          [ [ Plain
+                                [ Str "Build-Tools"
+                                , Space
+                                , Str "einsetzen"
+                                ]
+                            ]
+                          , [ Plain
+                                [ Str "Testen"
+                                , Space
+                                , Str "von"
+                                , Space
+                                , Str "Software"
+                                ]
+                            ]
+                          , [ Plain
+                                [ Str "Refactoring"
+                                , Space
+                                , Str "von"
+                                , Space
+                                , Quoted
+                                    DoubleQuote [ Str "stinkendem" ]
+                                , Space
+                                , Str "Code"
+                                ]
+                            ]
+                          , [ Plain
+                                [ Str "Versionsverwaltung:"
+                                , Space
+                                , Str "Git"
+                                ]
+                            ]
+                          ]
+                      ]
+                    , [ Plain
+                          [ Str "Zusammenarbeit"
+                          , Space
+                          , Str "in"
+                          , Space
+                          , Str "Teams:"
+                          , Space
+                          , Str "Verwaltung"
+                          , Space
+                          , Str "von"
+                          , Space
+                          , Str "Software"
+                          , Space
+                          , Str "und"
+                          , Space
+                          , Str "Workflows"
+                          ]
+                      ]
+                    ]
+                ]
+              ]
+          , Para
+              [ Span
+                  ( "" , [ "slides" ] , [] )
+                  [ Span
+                      ( "" , [ "bsp" ] , [] )
+                      [ Str "Warum"
+                      , Space
+                      , Str "ist"
+                      , Space
+                      , Str "guter"
+                      , Space
+                      , Str "Code"
+                      , Space
+                      , Str "wichtig?"
+                      ]
+                  ]
+              , SoftBreak
+              , Span
+                  ( "" , [ "notes" ] , [] )
+                  [ Strong
+                      [ Str "Warum"
+                      , Space
+                      , Str "ist"
+                      , Space
+                      , Str "guter"
+                      , Space
+                      , Str "Code"
+                      , Space
+                      , Str "wichtig?"
+                      ]
+                  ]
+              ]
+          , Para
+              [ Span
+                  ( "" , [ "notes" ] , [] )
+                  [ Str "=>"
+                  , Space
+                  , Str "Guter"
+                  , Space
+                  , Str "Code"
+                  , Space
+                  , Str "ist"
+                  , Space
+                  , Str "vor"
+                  , Space
+                  , Str "allem"
+                  , Space
+                  , Str "wichtig"
+                  , Space
+                  , Span
+                      ( "" , [ "alert" ] , [] )
+                      [ Str "f\252r"
+                      , Space
+                      , Str "den"
+                      , Space
+                      , Str "Entwickler"
+                      ]
+                  , Str "!"
+                  ]
+              ]
+          , Header
+              2
+              ( "\252berblick-modulinhalte" , [] , [] )
+              [ Str "\220berblick" , Space , Str "Modulinhalte" ]
+          , OrderedList
+              ( 1 , Decimal , Period )
+              [ [ Plain
+                    [ Str "Fortgeschrittene"
+                    , Space
+                    , Str "Konzepte"
+                    , Space
+                    , Str "in"
+                    , Space
+                    , Str "Java"
+                    ]
+                , BulletList
+                    [ [ Plain
+                          [ Str "Funktionale"
+                          , Space
+                          , Str "Programmierung:"
+                          , Space
+                          , Str "Default-Methoden,"
+                          , Space
+                          , Str "Funktionsinterfaces,"
+                          , Space
+                          , Str "Methodenreferenzen,"
+                          , Space
+                          , Str "Lambdas,"
+                          , Space
+                          , Str "Stream-API"
+                          ]
+                      ]
+                    , [ Plain
+                          [ Str "Generische"
+                          , Space
+                          , Str "Programmierung:"
+                          , Space
+                          , Str "Generics"
+                          ]
+                      ]
+                    , [ Plain
+                          [ Str "Parallele"
+                          , Space
+                          , Str "Programmierung:"
+                          , Space
+                          , Str "Threads"
+                          ]
+                      ]
+                    , [ Plain
+                          [ Str "Regul\228re"
+                          , Space
+                          , Str "Ausdr\252cke,"
+                          , Space
+                          , Str "Annotationen,"
+                          , Space
+                          , Str "Reflection"
+                          ]
+                      ]
+                    , [ Plain
+                          [ Str "CLI,"
+                          , Space
+                          , Str "Konfiguration,"
+                          , Space
+                          , Str "Fremde"
+                          , Space
+                          , Str "APIs"
+                          , Space
+                          , Str "nutzen"
+                          ]
+                      ]
+                    ]
+                ]
+              ]
+          , RawBlock (Format "tex") "\\smallskip"
+          , OrderedList
+              ( 2 , Decimal , Period )
+              [ [ Plain
+                    [ Str "Fortgeschrittenes"
+                    , Space
+                    , Str "OO-Design"
+                    ]
+                , BulletList
+                    [ [ Plain
+                          [ Str "Entwurfsmuster:"
+                          , Space
+                          , Str "Strategy,"
+                          , Space
+                          , Str "Template-Method,"
+                          , Space
+                          , Str "Factory-Method,"
+                          , Space
+                          , Str "Singleton,"
+                          , Space
+                          , Str "Observer,"
+                          , Space
+                          , Str "Visitor,"
+                          , Space
+                          , Str "Command,"
+                          , Space
+                          , Str "\8230"
+                          ]
+                      ]
+                    ]
+                ]
+              ]
+          , RawBlock (Format "tex") "\\smallskip"
+          , OrderedList
+              ( 3 , Decimal , Period )
+              [ [ Plain [ Str "Programmiermethoden" ]
+                , BulletList
+                    [ [ Plain
+                          [ Str "Versionskontrolle:"
+                          , Space
+                          , Str "Git"
+                          ]
+                      ]
+                    , [ Plain
+                          [ Str "Testen,"
+                          , Space
+                          , Str "Coding"
+                          , Space
+                          , Str "Conventions,"
+                          , Space
+                          , Str "Refactoring"
+                          ]
+                      ]
+                    , [ Plain
+                          [ Str "Logging,"
+                          , Space
+                          , Str "Build-Tools,"
+                          , Space
+                          , Str "CI"
+                          ]
+                      ]
+                    ]
+                ]
+              ]
+          , Header
+              2
+              ( "erwartungen-an-sie" , [] , [] )
+              [ Str "Erwartungen"
+              , Space
+              , Str "an"
+              , Space
+              , Str "Sie"
+              ]
+          , Para
+              [ Image
+                  ( "" , [] , [ ( "width" , "80%" ) ] )
+                  []
+                  ( "orga/img/modulbeschreibung.png" , "" )
+              ]
+          , BulletList
+              [ [ Plain
+                    [ Str "135h"
+                    , Space
+                    , Str "Selbststudium"
+                    , Space
+                    , Str "=>"
+                    , Space
+                    , Str "ca."
+                    , Space
+                    , Str "9h"
+                    , Space
+                    , Str "Arbeitszeit"
+                    , Space
+                    , Str "pro"
+                    , Space
+                    , Str "Woche!"
+                    ]
+                ]
+              ]
+          , Para
+              [ Str "Zeiten"
+              , Space
+              , Str "sind"
+              , Space
+              , Str "Richtwerte!"
+              , Space
+              , Str "-"
+              , Space
+              , Str "Manche"
+              , Space
+              , Str "brauchen"
+              , Space
+              , Str "l\228nger,"
+              , Space
+              , Str "manche"
+              , Space
+              , Str "sind"
+              , Space
+              , Str "schneller"
+              , Space
+              , Str "\8230"
+              ]
+          , Para
+              [ Str "Die"
+              , Space
+              , Str "Praktikumsaufgaben"
+              , Space
+              , Str "sollen"
+              , Space
+              , Str "Ihnen"
+              , Space
+              , Str "helfen,"
+              , Space
+              , Str "sich"
+              , Space
+              , Str "mit"
+              , Space
+              , Str "den"
+              , Space
+              , Str "Inhalten"
+              , Space
+              , Str "der"
+              , SoftBreak
+              , Str "Vorlesung"
+              , Space
+              , Str "auseinander"
+              , Space
+              , Str "zu"
+              , Space
+              , Str "setzen."
+              , Space
+              , Str "Die"
+              , Space
+              , Str "Abgabeform"
+              , Space
+              , Str "und"
+              , Space
+              , Str "die"
+              , Space
+              , Str "Bedingungen"
+              , Space
+              , Str "an"
+              , Space
+              , Str "das"
+              , SoftBreak
+              , Str "Testat"
+              , Space
+              , Str "sind"
+              , Space
+              , Str "bewusst"
+              , Space
+              , Str "so"
+              , Space
+              , Str "gew\228hlt,"
+              , Space
+              , Str "damit"
+              , Space
+              , Str "Sie"
+              , Space
+              , Str "im"
+              , Space
+              , Str "Praktikum"
+              , Space
+              , Str "untereinander"
+              , Space
+              , Str "in"
+              , Space
+              , Str "eine"
+              , SoftBreak
+              , Str "Diskussion"
+              , Space
+              , Str "eintreten"
+              , Space
+              , Str "(k\246nnen)."
+              , Space
+              , Str "Nutzen"
+              , Space
+              , Str "Sie"
+              , Space
+              , Str "diese"
+              , Space
+              , Str "Chance"
+              , Space
+              , Str "und"
+              , Space
+              , Str "verhalten"
+              , Space
+              , Str "Sie"
+              , Space
+              , Str "sich"
+              , SoftBreak
+              , Str "aktiv"
+              , Space
+              , Str "-"
+              , Space
+              , Str "so"
+              , Space
+              , Str "macht"
+              , Space
+              , Str "das"
+              , Space
+              , Str "Praktikum"
+              , Space
+              , Str "Spa\223"
+              , Space
+              , Str "und"
+              , Space
+              , Str "bringt"
+              , Space
+              , Str "allen"
+              , Space
+              , Str "mehr."
+              ]
+          , Para
+              [ Str "Studieren"
+              , Space
+              , Str "Sie!"
+              , Space
+              , Str "Studieren"
+              , Space
+              , Str "bedeutet,"
+              , Space
+              , Str "sich"
+              , Space
+              , Strong [ Str "selbstst\228ndig" ]
+              , Space
+              , Str "mit"
+              , Space
+              , Str "einem"
+              , Space
+              , Str "Thema"
+              , SoftBreak
+              , Str "auseinander"
+              , Space
+              , Str "zu"
+              , Space
+              , Str "setzen,"
+              , Space
+              , Str "zu"
+              , Space
+              , Str "vertiefen,"
+              , Space
+              , Str "zu"
+              , Space
+              , Str "\252ben,"
+              , Space
+              , Str "Zusammenh\228nge"
+              , Space
+              , Str "herzustellen."
+              , SoftBreak
+              , Str "Die"
+              , Space
+              , Str "Lehrveranstaltung"
+              , Space
+              , Str "unterst\252tzt"
+              , Space
+              , Str "Sie"
+              , Space
+              , Str "dabei,"
+              , Space
+              , Str "indem"
+              , Space
+              , Str "die"
+              , Space
+              , Str "wichtigsten"
+              , Space
+              , Str "Themen"
+              , SoftBreak
+              , Str "ausgesucht,"
+              , Space
+              , Str "in"
+              , Space
+              , Str "eine"
+              , Space
+              , Str "zeitliche"
+              , Space
+              , Str "Reihenfolge"
+              , Space
+              , Str "gebracht"
+              , Space
+              , Str "und"
+              , Space
+              , Str "didaktisch"
+              , Space
+              , Str "aufbereitet"
+              , SoftBreak
+              , Str "werden,"
+              , Space
+              , Str "so"
+              , Space
+              , Str "dass"
+              , Space
+              , Str "Sie"
+              , Space
+              , Str "sich"
+              , Space
+              , Str "die"
+              , Space
+              , Str "Inhalte"
+              , Space
+              , Str "leichter"
+              , Space
+              , Str "erschlie\223en"
+              , Space
+              , Str "k\246nnen."
+              , Space
+              , Str "Es"
+              , Space
+              , Str "gibt"
+              , SoftBreak
+              , Str "aber"
+              , Space
+              , Str "viele"
+              , Space
+              , Str "weitere"
+              , Space
+              , Str "Themen"
+              , Space
+              , Str "und"
+              , Space
+              , Str "Dinge,"
+              , Space
+              , Str "die"
+              , Space
+              , Str "nicht"
+              , Space
+              , Str "besprochen"
+              , Space
+              , Str "werden"
+              , Space
+              , Str "k\246nnen"
+              , Space
+              , Str "(schon"
+              , SoftBreak
+              , Str "aus"
+              , Space
+              , Str "rein"
+              , Space
+              , Str "zeitlichen"
+              , Space
+              , Str "Gr\252nden),"
+              , Space
+              , Str "die"
+              , Space
+              , Str "aber"
+              , Space
+              , Str "(f\252r"
+              , Space
+              , Str "Sie"
+              , Space
+              , Str "und/oder"
+              , Space
+              , Str "das"
+              , Space
+              , Str "Themengebiet)"
+              , SoftBreak
+              , Str "interessant"
+              , Space
+              , Str "sein"
+              , Space
+              , Str "k\246nnen!"
+              ]
+          , Para
+              [ Str "Pr\252fungsrelevant"
+              , Space
+              , Str "sind"
+              , Space
+              , Str "selbstverst\228ndlich"
+              , Space
+              , Str "nur"
+              , Space
+              , Str "die"
+              , Space
+              , Str "besprochenen"
+              , Space
+              , Str "Inhalte."
+              , Space
+              , Str "Der"
+              , SoftBreak
+              , Str "Fokus"
+              , Space
+              , Str "liegt"
+              , Space
+              , Str "aber"
+              , Space
+              , Str "auf"
+              , Space
+              , Str "dem"
+              , Space
+              , Quoted DoubleQuote [ Str "K\246nnen" ]
+              , Str ","
+              , Space
+              , Str "also"
+              , Space
+              , Str "dem"
+              , Space
+              , Strong [ Str "Beherrschen" ]
+              , Space
+              , Str "der"
+              , Space
+              , Str "jeweiligen"
+              , SoftBreak
+              , Str "Themen."
+              ]
+          , Header
+              2
+              ( "kognitive-stufen---einordnung-lernziele" , [] , [] )
+              [ Str "Kognitive"
+              , Space
+              , Str "Stufen"
+              , Space
+              , Str "-"
+              , Space
+              , Str "Einordnung"
+              , Space
+              , Str "Lernziele"
+              ]
+          , DefinitionList
+              [ ( [ Str "Kennen" , Space , Str "(K1)" ]
+                , [ [ Plain
+                        [ Str "Abruf"
+                        , Space
+                        , Str "von"
+                        , Space
+                        , Str "Informationen"
+                        , Space
+                        , Str "(Begriffe,"
+                        , Space
+                        , Str "Fakten,"
+                        , Space
+                        , Str "Prinzipien)"
+                        ]
+                    ]
+                  , [ Plain
+                        [ Str "(erkennen,"
+                        , Space
+                        , Str "nennen,"
+                        , Space
+                        , Str "bezeichnen,"
+                        , Space
+                        , Str "wiedergeben,"
+                        , Space
+                        , Str "kennen)"
+                        ]
+                    ]
+                  ]
+                )
+              , ( [ Str "Verstehen" , Space , Str "(K2)" ]
+                , [ [ Plain
+                        [ Str "Begr\252nden"
+                        , Space
+                        , Str "und"
+                        , Space
+                        , Str "Erl\228utern"
+                        , Space
+                        , Str "von"
+                        , Space
+                        , Str "Aussagen"
+                        , Space
+                        , Str "zum"
+                        , Space
+                        , Str "Thema"
+                        ]
+                    ]
+                  , [ Plain
+                        [ Str "(beschreiben,"
+                        , Space
+                        , Str "zusammenfassen,"
+                        , Space
+                        , Str "vergleichen,"
+                        , Space
+                        , Str "klassifizieren,"
+                        , Space
+                        , Str "begr\252nden,"
+                        , Space
+                        , Str "erkl\228ren)"
+                        ]
+                    ]
+                  ]
+                )
+              , ( [ Str "Anwenden" , Space , Str "(K3)" ]
+                , [ [ Plain
+                        [ Str "\220bertragung"
+                        , Space
+                        , Str "von"
+                        , Space
+                        , Str "erworbenem"
+                        , Space
+                        , Str "Wissen"
+                        , Space
+                        , Str "auf"
+                        , Space
+                        , Str "neue"
+                        , Space
+                        , Str "Situationen"
+                        , Space
+                        , Str "oder"
+                        , Space
+                        , Str "Anwendung"
+                        , Space
+                        , Str "zur"
+                        , Space
+                        , Str "Probleml\246sung"
+                        ]
+                    ]
+                  , [ Plain
+                        [ Str "(ausf\252hren,"
+                        , Space
+                        , Str "anwenden,"
+                        , Space
+                        , Str "beurteilen,"
+                        , Space
+                        , Str "entwerfen,"
+                        , Space
+                        , Str "nutzen)"
+                        ]
+                    ]
+                  ]
+                )
+              ]
+          , Para
+              [ Str "Nach"
+              , Space
+              , Emph
+                  [ Str "Anderson,"
+                  , Space
+                  , Str "Krathwohl"
+                  , Space
+                  , Str "(eds)"
+                  ]
+              , Str ":"
+              , Space
+              , Quoted
+                  DoubleQuote
+                  [ Str "A"
+                  , Space
+                  , Str "Taxonomy"
+                  , Space
+                  , Str "for"
+                  , Space
+                  , Str "Learning,"
+                  , Space
+                  , Str "Teaching,"
+                  , Space
+                  , Str "and"
+                  , SoftBreak
+                  , Str "Assessing:"
+                  , Space
+                  , Str "A"
+                  , Space
+                  , Str "Revision"
+                  , Space
+                  , Str "of"
+                  , Space
+                  , Str "Bloom\8217s"
+                  , Space
+                  , Str "Taxonomy"
+                  , Space
+                  , Str "of"
+                  , Space
+                  , Str "Educational"
+                  , Space
+                  , Str "Objectives"
+                  ]
+              , Str ","
+              , SoftBreak
+              , Str "Allyn"
+              , Space
+              , Str "&"
+              , Space
+              , Str "Bacon,"
+              , Space
+              , Str "2001"
+              ]
+          , Para []
+          ]
+        , [ Para []
+          , Header
+              2
+              ( "was-brauche-ich-literatur" , [] , [] )
+              [ Str "Was"
+              , Space
+              , Str "brauche"
+              , Space
+              , Str "ich?"
+              , Space
+              , Str "Literatur"
+              , Space
+              , Str "\8230"
+              ]
+          , Header
+              3
+              ( "basics-must-have" , [] , [] )
+              [ Str "Basics"
+              , Space
+              , Str "("
+              , Quoted DoubleQuote [ Str "Must" , Space , Str "Have" ]
+              , Str "!)"
+              ]
+          , OrderedList
+              ( 1 , Decimal , Period )
+              [ [ Plain
+                    [ Quoted
+                        DoubleQuote
+                        [ Strong
+                            [ Str "Java"
+                            , Space
+                            , Str "ist"
+                            , Space
+                            , Str "auch"
+                            , Space
+                            , Str "eine"
+                            , Space
+                            , Str "Insel"
+                            ]
+                        ]
+                    , Str ":"
+                    , Space
+                    , Cite
+                        [ Citation
+                            { citationId = "Ullenboom2021"
+                            , citationPrefix = []
+                            , citationSuffix = []
+                            , citationMode = AuthorInText
+                            , citationNoteNum = 8
+                            , citationHash = 0
+                            }
+                        ]
+                        [ Str "@Ullenboom2021" ]
+                    ]
+                ]
+              , [ Plain
+                    [ Quoted
+                        DoubleQuote
+                        [ Strong [ Str "Pro" , Space , Str "Git" ]
+                        , Space
+                        , Str "(Second"
+                        , Space
+                        , Str "Edition)"
+                        ]
+                    , Str ":"
+                    , Space
+                    , Cite
+                        [ Citation
+                            { citationId = "Chacon2014"
+                            , citationPrefix = []
+                            , citationSuffix = []
+                            , citationMode = AuthorInText
+                            , citationNoteNum = 9
+                            , citationHash = 0
+                            }
+                        ]
+                        [ Str "@Chacon2014" ]
+                    ]
+                ]
+              , [ Plain
+                    [ Quoted
+                        DoubleQuote
+                        [ Strong
+                            [ Str "The"
+                            , Space
+                            , Str "Java"
+                            , Space
+                            , Str "Tutorials"
+                            ]
+                        ]
+                    , Str ":"
+                    , Space
+                    , Cite
+                        [ Citation
+                            { citationId = "Java-SE-Tutorial"
+                            , citationPrefix = []
+                            , citationSuffix = []
+                            , citationMode = AuthorInText
+                            , citationNoteNum = 10
+                            , citationHash = 0
+                            }
+                        ]
+                        [ Str "@Java-SE-Tutorial" ]
+                    ]
+                ]
+              , [ Plain
+                    [ Quoted
+                        DoubleQuote
+                        [ Strong [ Str "Learn" , Space , Str "Java" ] ]
+                    , Str ":"
+                    , Space
+                    , Cite
+                        [ Citation
+                            { citationId = "LernJava"
+                            , citationPrefix = []
+                            , citationSuffix = []
+                            , citationMode = AuthorInText
+                            , citationNoteNum = 11
+                            , citationHash = 0
+                            }
+                        ]
+                        [ Str "@LernJava" ]
+                    ]
+                ]
+              ]
+          , Header
+              3
+              ( "weitere-empfohlene-literatur" , [] , [] )
+              [ Str "Weitere"
+              , Space
+              , Str "empfohlene"
+              , Space
+              , Str "Literatur"
+              ]
+          , Para
+              [ Str "Auf"
+              , Space
+              , Link
+                  ( "" , [] , [] )
+                  [ Str "The"
+                  , Space
+                  , Str "2023"
+                  , Space
+                  , Str "Java"
+                  , Space
+                  , Str "Programmer"
+                  , Space
+                  , Str "RoadMap"
+                  ]
+                  ( "https://medium.com/javarevisited/the-java-programmer-roadmap-f9db163ef2c2"
+                  , ""
+                  )
+              , SoftBreak
+              , Str "finden"
+              , Space
+              , Str "Sie"
+              , Space
+              , Str "eine"
+              , Space
+              , Str "Art"
+              , Space
+              , Str "Roadmap"
+              , Space
+              , Str "zu"
+              , Space
+              , Str "den"
+              , Space
+              , Str "verschiedenen"
+              , Space
+              , Str "Themen"
+              , Space
+              , Str "rund"
+              , Space
+              , Str "um"
+              , Space
+              , Str "die"
+              , Space
+              , Str "Java-Programmierung,"
+              , Space
+              , Str "die"
+              , SoftBreak
+              , Str "beinahe"
+              , Space
+              , Str "auch"
+              , Space
+              , Str "die"
+              , Space
+              , Str "Roadmap"
+              , Space
+              , Str "f\252r"
+              , Space
+              , Str "die"
+              , Space
+              , Str "Veranstaltung"
+              , Space
+              , Quoted DoubleQuote [ Str "Programmiermethoden" ]
+              , Space
+              , Str "sein"
+              , Space
+              , Str "k\246nnte"
+              , Space
+              , Str "\8230"
+              ]
+          , Para
+              [ Str "Joshua"
+              , Space
+              , Str "Bloch,"
+              , Space
+              , Str "einer"
+              , Space
+              , Str "der"
+              , Space
+              , Quoted DoubleQuote [ Str "V\228ter" ]
+              , Space
+              , Str "von"
+              , Space
+              , Str "Java,"
+              , Space
+              , Str "hat"
+              , Space
+              , Str "eine"
+              , Space
+              , Str "interessante"
+              , Space
+              , Str "Sammlung"
+              , Space
+              , Str "von"
+              , Space
+              , Str "Rezepten"
+              , Space
+              , Str "f\252r"
+              , SoftBreak
+              , Str "typische"
+              , Space
+              , Str "Probleme"
+              , Space
+              , Str "und"
+              , Space
+              , Str "wie"
+              , Space
+              , Str "man"
+              , Space
+              , Str "diese"
+              , Space
+              , Str "am"
+              , Space
+              , Str "sinnvollsten"
+              , Space
+              , Str "in"
+              , Space
+              , Str "Java"
+              , Space
+              , Str "l\246sen"
+              , Space
+              , Str "kann"
+              , Space
+              , Str "gesammelt:"
+              , Space
+              , Cite
+                  [ Citation
+                      { citationId = "Bloch2018"
+                      , citationPrefix = []
+                      , citationSuffix = []
+                      , citationMode = AuthorInText
+                      , citationNoteNum = 12
+                      , citationHash = 0
+                      }
+                  ]
+                  [ Str "@Bloch2018" ]
+              , SoftBreak
+              , Str "bzw."
+              , Space
+              , Cite
+                  [ Citation
+                      { citationId = "Bloch2011"
+                      , citationPrefix = []
+                      , citationSuffix = []
+                      , citationMode = AuthorInText
+                      , citationNoteNum = 13
+                      , citationHash = 0
+                      }
+                  ]
+                  [ Str "@Bloch2011" ]
+              , Space
+              , Str "(\228ltere"
+              , Space
+              , Str "Version)."
+              , Space
+              , Str "Mit"
+              , Space
+              , Cite
+                  [ Citation
+                      { citationId = "Inden2013"
+                      , citationPrefix = []
+                      , citationSuffix = []
+                      , citationMode = AuthorInText
+                      , citationNoteNum = 14
+                      , citationHash = 0
+                      }
+                  ]
+                  [ Str "@Inden2013" ]
+              , Space
+              , Str "gibt"
+              , Space
+              , Str "es"
+              , Space
+              , Str "ein"
+              , Space
+              , Str "extrem"
+              , Space
+              , Str "umfangreiches"
+              , SoftBreak
+              , Str "Nachschlagewerk"
+              , Space
+              , Str "zu"
+              , Space
+              , Str "(fast)"
+              , Space
+              , Str "allen"
+              , Space
+              , Str "Themen"
+              , Space
+              , Str "in"
+              , Space
+              , Str "Java"
+              , Space
+              , Str "(wird"
+              , Space
+              , Str "gelegentlich"
+              , Space
+              , Str "aktualisiert)."
+              , Space
+              , Str "Und"
+              , Space
+              , Str "die"
+              , SoftBreak
+              , Str "Developer"
+              , Space
+              , Str "Guides"
+              , Space
+              , Str "von"
+              , Space
+              , Str "Oracle"
+              , Space
+              , Cite
+                  [ Citation
+                      { citationId = "JDK-Doc"
+                      , citationPrefix = []
+                      , citationSuffix = []
+                      , citationMode = NormalCitation
+                      , citationNoteNum = 15
+                      , citationHash = 0
+                      }
+                  ]
+                  [ Str "[@JDK-Doc]" ]
+              , Space
+              , Str "sind"
+              , Space
+              , Str "ebenfalls"
+              , Space
+              , Str "eine"
+              , Space
+              , Str "gute"
+              , Space
+              , Str "Referenz."
+              ]
+          , Para
+              [ Str "Mit"
+              , Space
+              , Str "Java"
+              , Space
+              , Str "8"
+              , Space
+              , Str "wurden"
+              , Space
+              , Str "einige"
+              , Space
+              , Str "interessante"
+              , Space
+              , Str "Features"
+              , Space
+              , Str "eingef\252hrt"
+              , Space
+              , Str "wie"
+              , Space
+              , Str "etwa"
+              , Space
+              , Str "Lambda-Ausdr\252cke"
+              , Space
+              , Str "und"
+              , SoftBreak
+              , Str "Funktionsinterfaces."
+              , Space
+              , Str "Hierzu"
+              , Space
+              , Str "ist"
+              , Space
+              , Cite
+                  [ Citation
+                      { citationId = "Urma2014"
+                      , citationPrefix = []
+                      , citationSuffix = []
+                      , citationMode = AuthorInText
+                      , citationNoteNum = 16
+                      , citationHash = 0
+                      }
+                  ]
+                  [ Str "@Urma2014" ]
+              , Space
+              , Str "eine"
+              , Space
+              , Str "gute"
+              , Space
+              , Str "Quelle."
+              , Space
+              , Str "F\252r"
+              , Space
+              , Str "das"
+              , Space
+              , Str "Update"
+              , Space
+              , Str "auf"
+              , Space
+              , Str "Java"
+              , Space
+              , Str "9"
+              , Space
+              , Str "kann"
+              , SoftBreak
+              , Str "man"
+              , Space
+              , Str "sich"
+              , Space
+              , Cite
+                  [ Citation
+                      { citationId = "Juneau2017"
+                      , citationPrefix = []
+                      , citationSuffix = []
+                      , citationMode = AuthorInText
+                      , citationNoteNum = 17
+                      , citationHash = 0
+                      }
+                  ]
+                  [ Str "@Juneau2017" ]
+              , Space
+              , Str "anschauen."
+              , Space
+              , Str "Sp\228tere"
+              , Space
+              , Str "Features"
+              , Space
+              , Str "wie"
+              , Space
+              , Str "Optional"
+              , Space
+              , Str "und"
+              , Space
+              , Str "die"
+              , Space
+              , Str "Stream-API"
+              , Space
+              , Str "und"
+              , SoftBreak
+              , Str "Record-Klassen"
+              , Space
+              , Str "sind"
+              , Space
+              , Str "sehr"
+              , Space
+              , Str "gut"
+              , Space
+              , Str "auf"
+              , Space
+              , Cite
+                  [ Citation
+                      { citationId = "LernJava"
+                      , citationPrefix = []
+                      , citationSuffix = []
+                      , citationMode = AuthorInText
+                      , citationNoteNum = 18
+                      , citationHash = 0
+                      }
+                  ]
+                  [ Str "@LernJava" ]
+              , Space
+              , Str "dokumentiert."
+              ]
+          , Para
+              [ Str "Mit"
+              , Space
+              , Cite
+                  [ Citation
+                      { citationId = "Passig2013"
+                      , citationPrefix = []
+                      , citationSuffix = []
+                      , citationMode = AuthorInText
+                      , citationNoteNum = 19
+                      , citationHash = 0
+                      }
+                  ]
+                  [ Str "@Passig2013" ]
+              , Space
+              , Str "ist"
+              , Space
+              , Str "ein"
+              , Space
+              , Str "wunderbar"
+              , Space
+              , Str "launiges"
+              , Space
+              , Str "Buch"
+              , Space
+              , Str "erschienen,"
+              , Space
+              , Str "wo"
+              , Space
+              , Str "typische"
+              , Space
+              , Str "Code-Smells"
+              , SoftBreak
+              , Str "diskutiert"
+              , Space
+              , Str "werden"
+              , Space
+              , Str "(wobei"
+              , Space
+              , Str "man"
+              , Space
+              , Str "manche"
+              , Space
+              , Str "Standpunkte"
+              , Space
+              , Str "hinterfragen"
+              , Space
+              , Str "sollte)."
+              , Space
+              , Str "Ein"
+              , Space
+              , Str "Standardwerk"
+              , Space
+              , Str "zu"
+              , SoftBreak
+              , Str "diesem"
+              , Space
+              , Str "Thema"
+              , Space
+              , Str "ist"
+              , Space
+              , Cite
+                  [ Citation
+                      { citationId = "Martin2009"
+                      , citationPrefix = []
+                      , citationSuffix = []
+                      , citationMode = AuthorInText
+                      , citationNoteNum = 20
+                      , citationHash = 0
+                      }
+                  ]
+                  [ Str "@Martin2009" ]
+              , Str "."
+              , Space
+              , Str "In"
+              , Space
+              , Cite
+                  [ Citation
+                      { citationId = "SWEGoogle"
+                      , citationPrefix = []
+                      , citationSuffix = []
+                      , citationMode = AuthorInText
+                      , citationNoteNum = 21
+                      , citationHash = 0
+                      }
+                  ]
+                  [ Str "@SWEGoogle" ]
+              , Space
+              , Str "werden"
+              , Space
+              , Str "Erfahrungen"
+              , Space
+              , Str "rund"
+              , Space
+              , Str "um"
+              , Space
+              , Str "die"
+              , SoftBreak
+              , Str "Softwareentwicklung"
+              , Space
+              , Str "dargestellt"
+              , Space
+              , Str "und"
+              , Space
+              , Str "kritisch"
+              , Space
+              , Str "hinterfragt"
+              , Space
+              , Str "-"
+              , Space
+              , Str "hier"
+              , Space
+              , Str "finden"
+              , Space
+              , Str "sich"
+              , Space
+              , Str "interessante"
+              , SoftBreak
+              , Str "Gedanken"
+              , Space
+              , Str "zum"
+              , Space
+              , Str "Thema"
+              , Space
+              , Str "Git,"
+              , Space
+              , Str "Testen,"
+              , Space
+              , Str "Code"
+              , Space
+              , Str "Style"
+              , Space
+              , Str "und"
+              , Space
+              , Str "vieles"
+              , Space
+              , Str "andere"
+              , Space
+              , Str "mehr."
+              ]
+          , Para
+              [ Str "Zum"
+              , Space
+              , Str "Thema"
+              , Space
+              , Str "Refactoring"
+              , Space
+              , Str "ist"
+              , Space
+              , Cite
+                  [ Citation
+                      { citationId = "Fowler2011"
+                      , citationPrefix = []
+                      , citationSuffix = []
+                      , citationMode = AuthorInText
+                      , citationNoteNum = 22
+                      , citationHash = 0
+                      }
+                  ]
+                  [ Str "@Fowler2011" ]
+              , Space
+              , Emph [ Str "DIE" ]
+              , Space
+              , Str "Referenz."
+              , Space
+              , Str "Auf"
+              , Space
+              , Cite
+                  [ Citation
+                      { citationId = "RefactoringGuru"
+                      , citationPrefix = []
+                      , citationSuffix = []
+                      , citationMode = AuthorInText
+                      , citationNoteNum = 23
+                      , citationHash = 0
+                      }
+                  ]
+                  [ Str "@RefactoringGuru" ]
+              , Space
+              , Str "finden"
+              , Space
+              , Str "Sie"
+              , Space
+              , Str "eine"
+              , SoftBreak
+              , Str "nett"
+              , Space
+              , Str "aufbereitete"
+              , Space
+              , Str "\220bersicht"
+              , Space
+              , Str "zum"
+              , Space
+              , Str "Thema"
+              , Space
+              , Str "Refactoring,"
+              , Space
+              , Str "aber"
+              , Space
+              , Str "auch"
+              , Space
+              , Str "eine"
+              , Space
+              , Str "Einbettung"
+              , Space
+              , Str "in"
+              , Space
+              , Str "die"
+              , SoftBreak
+              , Str "Zusammenh\228nge"
+              , Space
+              , Str "mit"
+              , Space
+              , Str "den"
+              , Space
+              , Str "Themen"
+              , Space
+              , Str "Bad"
+              , Space
+              , Str "Smells"
+              , Space
+              , Str "und"
+              , Space
+              , Str "Clean"
+              , Space
+              , Str "Code."
+              ]
+          , Para
+              [ Str "Wer"
+              , Space
+              , Str "Interesse"
+              , Space
+              , Str "an"
+              , Space
+              , Str "UML"
+              , Space
+              , Str "und/oder"
+              , Space
+              , Str "Designpattern"
+              , Space
+              , Str "hat,"
+              , Space
+              , Str "sollte"
+              , Space
+              , Str "in"
+              , Space
+              , Cite
+                  [ Citation
+                      { citationId = "Oestereich2012"
+                      , citationPrefix = []
+                      , citationSuffix = []
+                      , citationMode = AuthorInText
+                      , citationNoteNum = 24
+                      , citationHash = 0
+                      }
+                  ]
+                  [ Str "@Oestereich2012" ]
+              , Space
+              , Str "sowie"
+              , Space
+              , Cite
+                  [ Citation
+                      { citationId = "UML25"
+                      , citationPrefix = []
+                      , citationSuffix = []
+                      , citationMode = AuthorInText
+                      , citationNoteNum = 25
+                      , citationHash = 0
+                      }
+                  ]
+                  [ Str "@UML25" ]
+              , SoftBreak
+              , Str "und"
+              , Space
+              , Cite
+                  [ Citation
+                      { citationId = "Gamma2011"
+                      , citationPrefix = []
+                      , citationSuffix = []
+                      , citationMode = AuthorInText
+                      , citationNoteNum = 26
+                      , citationHash = 0
+                      }
+                  ]
+                  [ Str "@Gamma2011" ]
+              , Space
+              , Str "sowie"
+              , Space
+              , Cite
+                  [ Citation
+                      { citationId = "Eilebrecht2013"
+                      , citationPrefix = []
+                      , citationSuffix = []
+                      , citationMode = AuthorInText
+                      , citationNoteNum = 27
+                      , citationHash = 0
+                      }
+                  ]
+                  [ Str "@Eilebrecht2013" ]
+              , Space
+              , Str "schauen."
+              ]
+          , Para
+              [ Str "Zum"
+              , Space
+              , Str "Thema"
+              , Space
+              , Str "Unit-Test"
+              , Space
+              , Str "seien"
+              , Space
+              , Cite
+                  [ Citation
+                      { citationId = "vogellaJUnit"
+                      , citationPrefix = []
+                      , citationSuffix = []
+                      , citationMode = AuthorInText
+                      , citationNoteNum = 28
+                      , citationHash = 0
+                      }
+                  ]
+                  [ Str "@vogellaJUnit" ]
+              , Str ","
+              , Space
+              , Cite
+                  [ Citation
+                      { citationId = "junit4"
+                      , citationPrefix = []
+                      , citationSuffix = []
+                      , citationMode = AuthorInText
+                      , citationNoteNum = 29
+                      , citationHash = 0
+                      }
+                  ]
+                  [ Str "@junit4" ]
+              , Str ","
+              , Space
+              , Cite
+                  [ Citation
+                      { citationId = "Osherove2014"
+                      , citationPrefix = []
+                      , citationSuffix = []
+                      , citationMode = AuthorInText
+                      , citationNoteNum = 30
+                      , citationHash = 0
+                      }
+                  ]
+                  [ Str "@Osherove2014" ]
+              , Space
+              , Str "und"
+              , Space
+              , Cite
+                  [ Citation
+                      { citationId = "Beck2014"
+                      , citationPrefix = []
+                      , citationSuffix = []
+                      , citationMode = AuthorInText
+                      , citationNoteNum = 31
+                      , citationHash = 0
+                      }
+                  ]
+                  [ Str "@Beck2014" ]
+              , Space
+              , Str "empfohlen."
+              ]
+          , Para
+              [ Str "Zum"
+              , Space
+              , Str "Thema"
+              , Space
+              , Str "Coding"
+              , Space
+              , Str "Conventions"
+              , Space
+              , Str "sind"
+              , Space
+              , Cite
+                  [ Citation
+                      { citationId = "SunMicrosystems1997"
+                      , citationPrefix = []
+                      , citationSuffix = []
+                      , citationMode = AuthorInText
+                      , citationNoteNum = 32
+                      , citationHash = 0
+                      }
+                  ]
+                  [ Str "@SunMicrosystems1997" ]
+              , Space
+              , Str "und"
+              , Space
+              , Cite
+                  [ Citation
+                      { citationId = "googlestyleguide"
+                      , citationPrefix = []
+                      , citationSuffix = []
+                      , citationMode = AuthorInText
+                      , citationNoteNum = 33
+                      , citationHash = 0
+                      }
+                  ]
+                  [ Str "@googlestyleguide" ]
+              , Space
+              , Str "gute"
+              , SoftBreak
+              , Str "Referenzen."
+              ]
+          , Para
+              [ Str "Hier"
+              , Space
+              , Str "noch"
+              , Space
+              , Str "eine"
+              , Space
+              , Str "Sammlung"
+              , Space
+              , Str "von"
+              , Space
+              , Str "Gedanken"
+              , Space
+              , Str "zum"
+              , Space
+              , Str "Berufsverst\228ndnis"
+              , Space
+              , Str "von"
+              , Space
+              , Str "Informatikern:"
+              , Space
+              , Cite
+                  [ Citation
+                      { citationId = "AtlassianHelloWorld"
+                      , citationPrefix = []
+                      , citationSuffix = []
+                      , citationMode = AuthorInText
+                      , citationNoteNum = 34
+                      , citationHash = 0
+                      }
+                  ]
+                  [ Str "@AtlassianHelloWorld" ]
+              , Str "."
+              ]
+          , Para
+              [ Str "Anregungen"
+              , Space
+              , Str "f\252r"
+              , Space
+              , Strong [ Str "Spielideen" ]
+              , Space
+              , Str "k\246nnen"
+              , Space
+              , Str "Sie"
+              , Space
+              , Str "beispielsweise"
+              , Space
+              , Str "in"
+              , Space
+              , Str "den"
+              , Space
+              , Str "folgenden"
+              , Space
+              , Str "Videos"
+              , Space
+              , Str "finden:"
+              , SoftBreak
+              , Str "-"
+              , Space
+              , Link
+                  ( "" , [] , [] )
+                  [ Str "Shattered"
+                  , Space
+                  , Str "Pixel"
+                  , Space
+                  , Str "Dungeon"
+                  , Space
+                  , Str "Rogue"
+                  , Space
+                  , Str "Beginners"
+                  , Space
+                  , Str "Guide"
+                  , Space
+                  , Str "Playthrough"
+                  ]
+                  ( "https://youtu.be/qoc_tDN0QC4" , "" )
+              , SoftBreak
+              , Str "-"
+              , Space
+              , Link
+                  ( "" , [] , [] )
+                  [ Str "Shattered"
+                  , Space
+                  , Str "Pixel"
+                  , Space
+                  , Str "Dungeon"
+                  , Space
+                  , Str "Duelist"
+                  , Space
+                  , Str "Update!"
+                  ]
+                  ( "https://youtu.be/LgSjUWjQg0s" , "" )
+              ]
+          , Para
+              [ Strong [ Str "Hinweis" ]
+              , Str ":"
+              , Space
+              , Str "Am"
+              , Space
+              , Str "Ende"
+              , Space
+              , Str "einer"
+              , Space
+              , Str "Vorlesung"
+              , Space
+              , Str "wird"
+              , Space
+              , Str "noch"
+              , Space
+              , Str "einmal"
+              , Space
+              , Str "spezifisch"
+              , Space
+              , Str "zum"
+              , Space
+              , Str "Thema"
+              , Space
+              , Str "passende"
+              , SoftBreak
+              , Str "Literatur"
+              , Space
+              , Str "empfohlen."
+              ]
+          , Header
+              2
+              ( "was-brauche-ich-noch-tools" , [] , [] )
+              [ Str "Was"
+              , Space
+              , Str "brauche"
+              , Space
+              , Str "ich"
+              , Space
+              , Str "noch?"
+              , Space
+              , Str "Tools"
+              , Space
+              , Str "\8230"
+              ]
+          , Header 3 ( "tools" , [] , [] ) [ Str "Tools" ]
+          , BulletList
+              [ [ Plain
+                    [ Str "JDK:"
+                    , Space
+                    , Str "Java"
+                    , Space
+                    , Str "SE"
+                    , Space
+                    , Str "17"
+                    , Space
+                    , Str "(LTS)"
+                    , Space
+                    , Str "("
+                    , Link
+                        ( "" , [] , [] )
+                        [ Str "Oracle" ]
+                        ( "https://www.oracle.com/java/technologies/downloads/"
+                        , ""
+                        )
+                    , Space
+                    , Str "oder"
+                    , SoftBreak
+                    , Link
+                        ( "" , [] , [] )
+                        [ Str "Alternativen" ]
+                        ( "https://code.visualstudio.com/docs/languages/java#_install-a-java-development-kit-jdk"
+                        , ""
+                        )
+                    , Str ","
+                    , SoftBreak
+                    , Str "bitte"
+                    , Space
+                    , Str "64-bit"
+                    , Space
+                    , Str "Version"
+                    , Space
+                    , Str "nutzen)"
+                    ]
+                ]
+              , [ Plain
+                    [ Str "IDE:"
+                    , Space
+                    , Link
+                        ( "" , [] , [] )
+                        [ Str "Eclipse"
+                        , Space
+                        , Str "IDE"
+                        , Space
+                        , Str "for"
+                        , Space
+                        , Str "Java"
+                        , Space
+                        , Str "Developers"
+                        ]
+                        ( "https://www.eclipse.org/downloads/" , "" )
+                    , Space
+                    , Str "oder"
+                    , SoftBreak
+                    , Link
+                        ( "" , [] , [] )
+                        [ Str "IntelliJ"
+                        , Space
+                        , Str "IDEA"
+                        , Space
+                        , Str "(Community"
+                        , Space
+                        , Str "Edition)"
+                        ]
+                        ( "https://www.jetbrains.com/idea/" , "" )
+                    , Space
+                    , Str "oder"
+                    , SoftBreak
+                    , Link
+                        ( "" , [] , [] )
+                        [ Str "Visual"
+                        , Space
+                        , Str "Studio"
+                        , Space
+                        , Str "Code"
+                        ]
+                        ( "https://code.visualstudio.com/" , "" )
+                    , Space
+                    , Str "oder"
+                    , Space
+                    , Link
+                        ( "" , [] , [] )
+                        [ Str "Vim" ]
+                        ( "https://www.vim.org/" , "" )
+                    , Space
+                    , Str "oder"
+                    , Space
+                    , Str "\8230"
+                    ]
+                ]
+              , [ Plain
+                    [ Link
+                        ( "" , [] , [] )
+                        [ Str "Git" ]
+                        ( "https://git-scm.com/" , "" )
+                    ]
+                ]
+              ]
+          , Header
+              3
+              ( "vorgaben-f\252r-die-aufgaben" , [] , [] )
+              [ Str "Vorgaben"
+              , Space
+              , Str "f\252r"
+              , Space
+              , Str "die"
+              , Space
+              , Str "Aufgaben"
+              ]
+          , BulletList
+              [ [ Plain
+                    [ Link
+                        ( "" , [] , [] )
+                        [ Str "Dungeon-Framework" ]
+                        ( "https://github.com/Programmiermethoden/Dungeon"
+                        , ""
+                        )
+                    ]
+                ]
+              ]
+          , Para []
+          ]
+        , [ Para []
+          , Header
+              2
+              ( "elektronische-klausur-termin-materialien" , [] , [] )
+              [ Str "Elektronische"
+              , Space
+              , Str "Klausur:"
+              , Space
+              , Str "Termin,"
+              , Space
+              , Str "Materialien"
+              ]
+          , Header 3 ( "termin" , [] , [] ) [ Str "Termin" ]
+          , Para
+              [ Str "Die"
+              , Space
+              , Str "Pr\252fung"
+              , Space
+              , Str "des"
+              , Space
+              , Str "theoretischen"
+              , Space
+              , Str "Teils"
+              , Space
+              , Str "der"
+              , Space
+              , Str "Performanzpr\252fung"
+              , Space
+              , Str "erfolgt"
+              , Space
+              , Str "durch"
+              , Space
+              , Str "eine"
+              , Space
+              , Str "Klausur,"
+              , Space
+              , Str "die"
+              , SoftBreak
+              , Str "als"
+              , Space
+              , Str "digitale"
+              , Space
+              , Str "Pr\252fung"
+              , Space
+              , Str "auf"
+              , Space
+              , Str "einem"
+              , Space
+              , Str "Pr\252fungs-ILIAS"
+              , Space
+              , Str "durchgef\252hrt"
+              , Space
+              , Str "wird."
+              ]
+          , Para
+              [ Str "Es"
+              , Space
+              , Str "wird"
+              , Space
+              , Str "angestrebt,"
+              , Space
+              , Str "die"
+              , Space
+              , Str "Klausur"
+              , Space
+              , Str "in"
+              , Space
+              , Str "Pr\228senz"
+              , Space
+              , Str "in"
+              , Space
+              , Str "den"
+              , Space
+              , Str "Rechnerpools"
+              , Space
+              , Str "am"
+              , Space
+              , Str "Campus"
+              , Space
+              , Str "Minden"
+              , Space
+              , Str "durchzuf\252hren."
+              , SoftBreak
+              , Str "Falls"
+              , Space
+              , Str "dies"
+              , Space
+              , Str "wegen"
+              , Space
+              , Str "der"
+              , Space
+              , Str "Corona-Situation"
+              , Space
+              , Str "oder"
+              , Space
+              , Str "anderer"
+              , Space
+              , Str "Umst\228nde"
+              , Space
+              , Str "nicht"
+              , Space
+              , Str "m\246glich"
+              , Space
+              , Str "sein"
+              , Space
+              , Str "sollte,"
+              , Space
+              , Str "wird"
+              , SoftBreak
+              , Str "die"
+              , Space
+              , Str "Klausur"
+              , Space
+              , Str "als"
+              , Space
+              , Quoted DoubleQuote [ Str "Open-Book-Ausarbeitung" ]
+              , Space
+              , Str "im"
+              , Space
+              , Str "Home-Office"
+              , Space
+              , Str "durchgef\252hrt."
+              ]
+          , Para
+              [ Str "Es"
+              , Space
+              , Str "wird"
+              , Space
+              , Str "in"
+              , Space
+              , Str "beiden"
+              , Space
+              , Str "Pr\252fungszeitr\228umen"
+              , Space
+              , Str "ein"
+              , Space
+              , Str "Termin"
+              , Space
+              , Str "angeboten."
+              , Space
+              , Str "Die"
+              , Space
+              , Str "Termine"
+              , Space
+              , Str "werden"
+              , Space
+              , Str "vom"
+              , Space
+              , Str "Pr\252fungsamt"
+              , SoftBreak
+              , Str "bekannt"
+              , Space
+              , Str "gegeben."
+              ]
+          , Para
+              [ Str "Dauer"
+              , Space
+              , Str "jeweils"
+              , Space
+              , Str "90"
+              , Space
+              , Str "Minuten."
+              ]
+          , BulletList
+              [ [ Plain
+                    [ Str "Die"
+                    , Space
+                    , Str "konkrete"
+                    , Space
+                    , Str "Durchf\252hrungsform"
+                    , Space
+                    , Span
+                        ( "" , [ "notes" ] , [] )
+                        [ Str "(in"
+                        , Space
+                        , Str "Pr\228senz"
+                        , Space
+                        , Str "am"
+                        , Space
+                        , Str "Campus"
+                        , Space
+                        , Str "Minden"
+                        , Space
+                        , Str "oder"
+                        , Space
+                        , Str "im"
+                        , Space
+                        , Str "Home-Office)"
+                        ]
+                    , SoftBreak
+                    , Str "wird"
+                    , Space
+                    , Str "Ihnen"
+                    , Space
+                    , Span
+                        ( "" , [ "notes" ] , [] )
+                        [ Str "sp\228testens" ]
+                    , Space
+                    , Str "zwei"
+                    , Space
+                    , Str "Wochen"
+                    , Space
+                    , Str "vor"
+                    , Space
+                    , Str "der"
+                    , Space
+                    , Str "Pr\252fung"
+                    , Space
+                    , Str "\252ber"
+                    , Space
+                    , Str "das"
+                    , Space
+                    , Str "LSF"
+                    , Space
+                    , Str "bekanntgegeben"
+                    ]
+                ]
+              , [ Plain
+                    [ Str "Die"
+                    , Space
+                    , Str "URL"
+                    , Space
+                    , Span
+                        ( "" , [ "notes" ] , [] )
+                        [ Str "zur" , Space , Str "Pr\252fung" ]
+                    , Space
+                    , Str "wird"
+                    , Space
+                    , Str "Ihnen"
+                    , Space
+                    , Str "jeweils"
+                    , Space
+                    , Str "ca."
+                    , Space
+                    , Str "eine"
+                    , Space
+                    , Str "Woche"
+                    , Space
+                    , Str "vorher"
+                    , Space
+                    , Str "per"
+                    , Space
+                    , Str "Mail"
+                    , Space
+                    , Str "\252ber"
+                    , Space
+                    , Str "das"
+                    , Space
+                    , Str "LSF"
+                    , SoftBreak
+                    , Span
+                        ( "" , [ "notes" ] , [] )
+                        [ Str "bzw."
+                        , Space
+                        , Str "das"
+                        , Space
+                        , Str "ILIAS"
+                        ]
+                    , Space
+                    , Str "bekanntgegeben"
+                    ]
+                ]
+              , [ Plain
+                    [ Str "Melden"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "sich"
+                    , Space
+                    , Str "im"
+                    , Space
+                    , Str "ILIAS-Pr\252fungsraum"
+                    , Space
+                    , Str "vor"
+                    , Space
+                    , Str "dem"
+                    , Space
+                    , Str "Pr\252fungstag"
+                    , Space
+                    , Str "per"
+                    , Space
+                    , Quoted
+                        DoubleQuote
+                        [ Str "Beitritt"
+                        , Space
+                        , Str "mit"
+                        , Space
+                        , Str "Best\228tigung"
+                        ]
+                    , Space
+                    , Str "an"
+                    , SoftBreak
+                    , Span
+                        ( "" , [ "notes" ] , [] )
+                        [ Str "(wie"
+                        , Space
+                        , Str "zu"
+                        , Space
+                        , Str "einem"
+                        , Space
+                        , Str "normalen"
+                        , Space
+                        , Str "Kurs)"
+                        ]
+                    ]
+                ]
+              ]
+          , Header
+              3
+              ( "zugelassene-hilfsmittel" , [] , [] )
+              [ Str "Zugelassene" , Space , Str "Hilfsmittel" ]
+          , Header 4 ( "pr\228senz" , [] , [] ) [ Str "Pr\228senz" ]
+          , Para
+              [ Strong [ Str "Zugelassene" , Space , Str "Materialien" ]
+              , Str ":"
+              , Space
+              , Span
+                  ( "" , [ "alert" ] , [] )
+                  [ Strong
+                      [ Str "DIN-A4-Spickzettel"
+                      , Space
+                      , Str "(beidseitig)"
+                      ]
+                  ]
+              ]
+          , Para
+              [ Str "Sie"
+              , Space
+              , Str "d\252rfen"
+              , Space
+              , Strong [ Str "einen" ]
+              , Space
+              , Str "Spickzettel"
+              , Space
+              , Str "im"
+              , Space
+              , Strong [ Str "DIN-A4" ]
+              , Str "-Format"
+              , Space
+              , Str "benutzen,"
+              , Space
+              , Str "der"
+              , Space
+              , Str "beidseitig"
+              , Space
+              , Str "beschrieben"
+              , SoftBreak
+              , Str "sein"
+              , Space
+              , Str "kann."
+              ]
+          , Para
+              [ Str "Ich"
+              , Space
+              , Str "m\246chte"
+              , Space
+              , Str "Sie"
+              , Space
+              , Str "hier"
+              , Space
+              , Str "noch"
+              , Space
+              , Str "einmal"
+              , Space
+              , Str "ermuntern,"
+              , Space
+              , Str "diesen"
+              , Space
+              , Str "Zettel"
+              , Space
+              , Str "tats\228chlich"
+              , Space
+              , Str "manuell"
+              , Space
+              , Str "zu"
+              , Space
+              , Str "erstellen"
+              , SoftBreak
+              , Str "(also"
+              , Space
+              , Str "ganz"
+              , Space
+              , Str "traditionell"
+              , Space
+              , Str "zu"
+              , Space
+              , Strong [ Str "schreiben" ]
+              , Str "),"
+              , Space
+              , Str "da"
+              , Space
+              , Str "bereits"
+              , Space
+              , Str "der"
+              , Space
+              , Str "Schreibvorgang"
+              , Space
+              , Str "einen"
+              , Space
+              , Str "gewissen"
+              , SoftBreak
+              , Str "Lerneffekt"
+              , Space
+              , Str "bewirkt!"
+              ]
+          , Header
+              4
+              ( "open-book-ausarbeitung" , [] , [] )
+              [ Str "Open-Book-Ausarbeitung" ]
+          , Para
+              [ Str "Falls"
+              , Space
+              , Str "die"
+              , Space
+              , Str "Pr\252fung"
+              , Space
+              , Str "als"
+              , Space
+              , Str "Open-Book-Ausarbeitung"
+              , Space
+              , Str "im"
+              , Space
+              , Str "Home-Office"
+              , Space
+              , Str "durchgef\252hrt"
+              , Space
+              , Str "werden"
+              , Space
+              , Str "sollte,"
+              , Space
+              , Str "d\252rfen"
+              , SoftBreak
+              , Str "Sie"
+              , Space
+              , Str "alle"
+              , Space
+              , Str "Unterlagen"
+              , Space
+              , Str "benutzen."
+              ]
+          , BulletList
+              [ [ Para
+                    [ Str "Ausnahme:"
+                    , Space
+                    , Strong
+                        [ Str "Keine"
+                        , Space
+                        , Str "Hilfe"
+                        , Space
+                        , Str "durch"
+                        , Space
+                        , Str "Dritte!"
+                        ]
+                    , Space
+                    , Str "(insbesondere"
+                    , Space
+                    , Str "keine"
+                    , Space
+                    , Str "Zusammenarbeit,"
+                    , Space
+                    , Str "keine"
+                    , Space
+                    , Str "Kommunikation)"
+                    ]
+                , Para
+                    [ Str "Sie"
+                    , Space
+                    , Str "sollen"
+                    , Space
+                    , Str "die"
+                    , Space
+                    , Str "Pr\252fung"
+                    , Space
+                    , Str "eigenst\228ndig"
+                    , Space
+                    , Str "bearbeiten."
+                    , Space
+                    , Str "Hilfe"
+                    , Space
+                    , Str "von"
+                    , Space
+                    , Str "Dritten"
+                    , Space
+                    , Str "sowie"
+                    , Space
+                    , Str "jegliche"
+                    , Space
+                    , Str "Kommunikation"
+                    , SoftBreak
+                    , Str "mit"
+                    , Space
+                    , Str "Dritten"
+                    , Space
+                    , Str "ist"
+                    , Space
+                    , Str "in"
+                    , Space
+                    , Str "keinem"
+                    , Space
+                    , Str "Fall"
+                    , Space
+                    , Str "zugelassen"
+                    , Space
+                    , Str "und"
+                    , Space
+                    , Str "wird"
+                    , Space
+                    , Str "als"
+                    , Space
+                    , Str "T\228uschungsversuch"
+                    , Space
+                    , Str "gewertet."
+                    ]
+                ]
+              ]
+          , Header 3 ( "einsicht" , [] , [] ) [ Str "Einsicht" ]
+          , BulletList
+              [ [ Plain
+                    [ Str "Pr\252fungseinsicht:"
+                    , Space
+                    , Str "Zeitnah;"
+                    , Space
+                    , Str "Bekanntgabe"
+                    , Space
+                    , Str "per"
+                    , Space
+                    , Str "Mail"
+                    ]
+                ]
+              ]
+          , Header
+              2
+              ( "technische-vorbereitungen" , [] , [] )
+              [ Str "Technische" , Space , Str "Vorbereitungen" ]
+          , Header
+              3
+              ( "pr\228senzpr\252fung-am-campus-minden" , [] , [] )
+              [ Str "Pr\228senzpr\252fung"
+              , Space
+              , Str "am"
+              , Space
+              , Str "Campus"
+              , Space
+              , Str "Minden"
+              ]
+          , Para
+              [ Str "Diese"
+              , Space
+              , Str "Bemerkungen"
+              , Space
+              , Str "betreffen"
+              , Space
+              , Str "die"
+              , Space
+              , Str "Durchf\252hrung"
+              , Space
+              , Str "als"
+              , Space
+              , Str "Pr\228senzpr\252fung"
+              , Space
+              , Str "in"
+              , Space
+              , Str "den"
+              , Space
+              , Str "R\228umen"
+              , Space
+              , Str "am"
+              , Space
+              , Str "Campus"
+              , Space
+              , Str "Minden."
+              ]
+          , BulletList
+              [ [ Para
+                    [ Strong [ Str "HSBI-Zugangsdaten" ]
+                    , Str ":"
+                    , Space
+                    , Str "Username,"
+                    , Space
+                    , Str "Passwort"
+                    ]
+                , Para
+                    [ Str "Bei"
+                    , Space
+                    , Str "der"
+                    , Space
+                    , Str "Durchf\252hrung"
+                    , Space
+                    , Str "der"
+                    , Space
+                    , Str "Pr\252fung"
+                    , Space
+                    , Str "am"
+                    , Space
+                    , Str "Campus"
+                    , Space
+                    , Str "Minden"
+                    , Space
+                    , Str "wird"
+                    , Space
+                    , Str "Ihnen"
+                    , Space
+                    , Str "ein"
+                    , Space
+                    , Str "Rechner"
+                    , Space
+                    , Str "zur"
+                    , Space
+                    , Str "Verf\252gung"
+                    , SoftBreak
+                    , Str "gestellt."
+                    , Space
+                    , Str "Dort"
+                    , Space
+                    , Str "l\228uft"
+                    , Space
+                    , Str "voraussichtlich"
+                    , Space
+                    , Str "ein"
+                    , Space
+                    , Str "Browser"
+                    , Space
+                    , Str "im"
+                    , Space
+                    , Str "Kiosk-Mode,"
+                    , Space
+                    , Str "wo"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "sich"
+                    , Space
+                    , Str "am"
+                    , Space
+                    , Str "Pr\252fungs-ILIAS"
+                    , SoftBreak
+                    , Str "anmelden."
+                    , Space
+                    , Str "Dazu"
+                    , Space
+                    , Str "ben\246tigen"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "ihre"
+                    , Space
+                    , Str "HSBI-Zugangsdaten,"
+                    , Space
+                    , Str "mit"
+                    , Space
+                    , Str "denen"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "sich"
+                    , Space
+                    , Str "auch"
+                    , Space
+                    , Str "im"
+                    , Space
+                    , Quoted DoubleQuote [ Str "normalen" ]
+                    , SoftBreak
+                    , Str "ILIAS"
+                    , Space
+                    , Str "anmelden."
+                    ]
+                ]
+              , [ Para
+                    [ Strong [ Str "Studierendenausweis" ]
+                    , Space
+                    , Str "und"
+                    , Space
+                    , Str "Personalausweis"
+                    ]
+                , Para
+                    [ Str "An"
+                    , Space
+                    , Str "der"
+                    , Space
+                    , Str "Pr\252fung"
+                    , Space
+                    , Str "d\252rfen"
+                    , Space
+                    , Str "nur"
+                    , Space
+                    , Str "Personen"
+                    , Space
+                    , Str "teilnehmen,"
+                    , Space
+                    , Str "die"
+                    , Space
+                    , Str "daf\252r"
+                    , Space
+                    , Str "im"
+                    , Space
+                    , Str "LSF"
+                    , Space
+                    , Str "angemeldet"
+                    , Space
+                    , Str "sind."
+                    , Space
+                    , Str "Es"
+                    , Space
+                    , Str "findet"
+                    , SoftBreak
+                    , Str "eine"
+                    , Space
+                    , Str "entsprechende"
+                    , Space
+                    , Str "Kontrolle"
+                    , Space
+                    , Str "statt."
+                    , Space
+                    , Str "Halten"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "Ihren"
+                    , Space
+                    , Str "Studierendenausweis"
+                    , Space
+                    , Str "und"
+                    , Space
+                    , Str "Personalausweis"
+                    , SoftBreak
+                    , Str "bereit."
+                    ]
+                ]
+              ]
+          , Header 3 ( "home-office" , [] , [] ) [ Str "Home-Office" ]
+          , Para
+              [ Str "Diese"
+              , Space
+              , Str "Bemerkungen"
+              , Space
+              , Str "betreffen"
+              , Space
+              , Str "die"
+              , Space
+              , Str "Durchf\252hrung"
+              , Space
+              , Str "aus"
+              , Space
+              , Str "dem"
+              , Space
+              , Str "Home-Office"
+              , Space
+              , Str "mit"
+              , Space
+              , Str "Ihrer"
+              , Space
+              , Str "Hardware."
+              , Space
+              , Str "Bei"
+              , Space
+              , Str "der"
+              , SoftBreak
+              , Str "Durchf\252hrung"
+              , Space
+              , Str "in"
+              , Space
+              , Str "Pr\228senz"
+              , Space
+              , Str "in"
+              , Space
+              , Str "den"
+              , Space
+              , Str "R\228umen"
+              , Space
+              , Str "am"
+              , Space
+              , Str "Campus"
+              , Space
+              , Str "Minden"
+              , Space
+              , Str "werden"
+              , Space
+              , Str "die"
+              , Space
+              , Str "technischen"
+              , Space
+              , Str "Details"
+              , Space
+              , Str "von"
+              , Space
+              , Str "uns"
+              , SoftBreak
+              , Str "f\252r"
+              , Space
+              , Str "Sie"
+              , Space
+              , Str "vorbereitet"
+              , Space
+              , Str "sein."
+              ]
+          , BulletList
+              [ [ Para
+                    [ Strong [ Str "Rechner" ]
+                    , Str ":"
+                    , Space
+                    , Str "Nutzen"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "f\252r"
+                    , Space
+                    , Str "die"
+                    , Space
+                    , Str "Pr\252fung"
+                    , Space
+                    , Str "einen"
+                    , Space
+                    , Str "station\228ren"
+                    , Space
+                    , Str "Rechner"
+                    , Space
+                    , Str "oder"
+                    , Space
+                    , Str "ein"
+                    , Space
+                    , Str "Notebook."
+                    ]
+                , Para
+                    [ Str "Vermeiden"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "die"
+                    , Space
+                    , Str "Verwendung"
+                    , Space
+                    , Str "von"
+                    , Space
+                    , Str "Tablets"
+                    , Space
+                    , Str "und"
+                    , Space
+                    , Str "Smartphones!"
+                    , Space
+                    , Str "Bei"
+                    , Space
+                    , Str "der"
+                    , Space
+                    , Str "Verwendung"
+                    , Space
+                    , Str "von"
+                    , Space
+                    , Str "Tablets"
+                    , SoftBreak
+                    , Str "kann"
+                    , Space
+                    , Str "es"
+                    , Space
+                    , Str "unter"
+                    , Space
+                    , Str "Umst\228nden"
+                    , Space
+                    , Str "zu"
+                    , Space
+                    , Str "Darstellungsproblemen"
+                    , Space
+                    , Str "kommen."
+                    , Space
+                    , Str "Smartphones"
+                    , Space
+                    , Str "sind"
+                    , Space
+                    , Str "aufgrund"
+                    , Space
+                    , Str "des"
+                    , Space
+                    , Str "kleinen"
+                    , SoftBreak
+                    , Str "Bildschirms"
+                    , Space
+                    , Str "f\252r"
+                    , Space
+                    , Str "die"
+                    , Space
+                    , Str "Pr\252fungsdurchf\252hrung"
+                    , Space
+                    , Str "schlicht"
+                    , Space
+                    , Str "ungeeignet."
+                    ]
+                , Para
+                    [ Str "Bei"
+                    , Space
+                    , Str "fehlendem"
+                    , Space
+                    , Str "Zugang"
+                    , Space
+                    , Str "zu"
+                    , Space
+                    , Str "einem"
+                    , Space
+                    , Str "entsprechenden"
+                    , Space
+                    , Str "Endger\228t"
+                    , Space
+                    , Str "kontaktieren"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "bitte"
+                    , Space
+                    , Str "fr\252hzeitig"
+                    , Space
+                    , Str "die"
+                    , SoftBreak
+                    , Str "Pr\252fungsverantwortlichen."
+                    ]
+                ]
+              , [ Para
+                    [ Strong [ Str "Netz" ]
+                    , Str ":"
+                    , Space
+                    , Str "Stabil"
+                    , Space
+                    , Str "genug?"
+                    , Space
+                    , Str "Belastbar"
+                    , Space
+                    , Str "genug?"
+                    ]
+                , Para
+                    [ Str "Wenn"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "keinen"
+                    , Space
+                    , Str "Zugang"
+                    , Space
+                    , Str "zu"
+                    , Space
+                    , Str "einer"
+                    , Space
+                    , Str "ausreichend"
+                    , Space
+                    , Str "stabilen"
+                    , Space
+                    , Str "Internetverbindung"
+                    , Space
+                    , Str "haben,"
+                    , Space
+                    , Str "setzen"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "sich"
+                    , SoftBreak
+                    , Str "fr\252hzeitig"
+                    , Space
+                    , Str "mit"
+                    , Space
+                    , Str "Ihren"
+                    , Space
+                    , Str "Pr\252fungsverantwortlichen"
+                    , Space
+                    , Str "in"
+                    , Space
+                    , Str "Verbindung."
+                    ]
+                ]
+              , [ Para
+                    [ Strong [ Str "VPN" ]
+                    , Str ":"
+                    , Space
+                    , Str "Der"
+                    , Space
+                    , Str "Pr\252fungs-ILIAS"
+                    , Space
+                    , Str "ist"
+                    , Space
+                    , Str "nur"
+                    , Space
+                    , Str "im"
+                    , Space
+                    , Str "HSBI-VPN"
+                    , Space
+                    , Str "erreichbar."
+                    ]
+                , Para
+                    [ Str "Installieren"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "den"
+                    , Space
+                    , Str "VPN-Client"
+                    , Space
+                    , Str "(Anleitung:"
+                    , Space
+                    , Link
+                        ( "" , [] , [] )
+                        [ Str "hsbi.de/dvz/faq/cat/7" ]
+                        ( "https://www.hsbi.de/dvz/faq/cat/7" , "" )
+                    , Str ")"
+                    , SoftBreak
+                    , Str "und"
+                    , Space
+                    , Str "testen"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "im"
+                    , Space
+                    , Str "Vorfeld"
+                    , Space
+                    , Str "der"
+                    , Space
+                    , Str "Pr\252fung"
+                    , Space
+                    , Str "bei"
+                    , Space
+                    , Str "aktivierter"
+                    , Space
+                    , Str "VPN-Verbindung"
+                    , Space
+                    , Str "den"
+                    , Space
+                    , Str "Zugang"
+                    , Space
+                    , Str "zur"
+                    , Space
+                    , Str "Pr\252fungsplattform"
+                    , SoftBreak
+                    , Link
+                        ( "" , [] , [] )
+                        [ Str "eassessment.hsbi.de" ]
+                        ( "https://eassessment.hsbi.de" , "" )
+                    , Str "."
+                    , Space
+                    , Str "Zugangsdaten"
+                    , Space
+                    , Str "wie"
+                    , Space
+                    , Str "im"
+                    , Space
+                    , Str "normalen"
+                    , SoftBreak
+                    , Str "ILIAS."
+                    ]
+                , Para
+                    [ Str "Achtung:"
+                    , Space
+                    , Str "Auch"
+                    , Space
+                    , Str "wenn"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "sich"
+                    , Space
+                    , Str "in"
+                    , Space
+                    , Str "den"
+                    , Space
+                    , Str "R\228umen"
+                    , Space
+                    , Str "der"
+                    , Space
+                    , Str "HSBI"
+                    , Space
+                    , Str "befinden,"
+                    , Space
+                    , Str "m\252ssen"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "oft"
+                    , Space
+                    , Str "die"
+                    , Space
+                    , Str "VPN-Verbindung"
+                    , Space
+                    , Str "aktivieren,"
+                    , SoftBreak
+                    , Str "um"
+                    , Space
+                    , Str "Zugang"
+                    , Space
+                    , Str "zur"
+                    , Space
+                    , Str "Pr\252fungsplattform"
+                    , Space
+                    , Str "zu"
+                    , Space
+                    , Str "erhalten."
+                    ]
+                ]
+              , [ Para
+                    [ Strong [ Str "Browser" ]
+                    , Str ":"
+                    , Space
+                    , Span
+                        ( "" , [ "notes" ] , [] )
+                        [ Str "Nutzen"
+                        , Space
+                        , Str "Sie"
+                        , Space
+                        , Str "einen"
+                        , Space
+                        , Str "der"
+                        ]
+                    , Space
+                    , Str "Standardbrowser"
+                    , Space
+                    , Str "(Edge,"
+                    , Space
+                    , Str "Firefox,"
+                    , Space
+                    , Str "Safari,"
+                    , Space
+                    , Str "Chrome/Chromium)"
+                    , SoftBreak
+                    , Str "in"
+                    , Space
+                    , Str "der"
+                    , Space
+                    , Str "Standardeinstellung:"
+                    , Space
+                    , Str "insbesondere"
+                    , Space
+                    , Str "JavaScript"
+                    , Space
+                    , Str "und"
+                    , Space
+                    , Str "Cookies"
+                    , Space
+                    , Str "m\252ssen"
+                    , Space
+                    , Str "aktiviert/erlaubt"
+                    , Space
+                    , Str "sein."
+                    ]
+                , Para
+                    [ Str "Deaktivieren"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "s\228mtliche"
+                    , Space
+                    , Str "Browser-Erweiterungen"
+                    , Space
+                    , Str "wie"
+                    , Space
+                    , Str "z.B."
+                    , Space
+                    , Str "Ad-Blocker"
+                    , Space
+                    , Str "(AdBlockPlus,"
+                    , Space
+                    , Str "uBlock,"
+                    , Space
+                    , Str "\8230)"
+                    , Space
+                    , Str "oder"
+                    , SoftBreak
+                    , Str "JavaScript-Blocker"
+                    , Space
+                    , Str "(No-Script,"
+                    , Space
+                    , Str "Ghostery,"
+                    , Space
+                    , Str "\8230)"
+                    , Space
+                    , Str "f\252r"
+                    , Space
+                    , Str "den"
+                    , Space
+                    , Str "Pr\252fungszeitraum."
+                    ]
+                , Para
+                    [ Strong
+                        [ Str "Nutzen"
+                        , Space
+                        , Str "Sie"
+                        , Space
+                        , Str "Ihren"
+                        , Space
+                        , Str "Browser"
+                        , Space
+                        , Str "nicht"
+                        , Space
+                        , Str "im"
+                        , Space
+                        , Str "Privacy-Modus!"
+                        ]
+                    ]
+                ]
+              , [ Para
+                    [ Strong [ Str "HSBI-Zugangsdaten" ]
+                    , Str ":"
+                    , Space
+                    , Str "Username,"
+                    , Space
+                    , Str "Passwort"
+                    ]
+                , Para
+                    [ Str "Bei"
+                    , Space
+                    , Str "der"
+                    , Space
+                    , Str "Durchf\252hrung"
+                    , Space
+                    , Str "der"
+                    , Space
+                    , Str "Pr\252fung"
+                    , Space
+                    , Str "als"
+                    , Space
+                    , Str "Open-Book-Ausarbeitung"
+                    , Space
+                    , Str "f\252hren"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "die"
+                    , Space
+                    , Str "Pr\252fung"
+                    , Space
+                    , Str "auf"
+                    , Space
+                    , Str "Ihrer"
+                    , SoftBreak
+                    , Str "eigenen"
+                    , Space
+                    , Str "Hardware"
+                    , Space
+                    , Str "im"
+                    , Space
+                    , Str "Home-Office"
+                    , Space
+                    , Str "durch."
+                    , Space
+                    , Str "Auch"
+                    , Space
+                    , Str "hier"
+                    , Space
+                    , Str "m\252ssen"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "sich"
+                    , Space
+                    , Str "am"
+                    , Space
+                    , Str "Pr\252fungs-ILIAS"
+                    , Space
+                    , Str "anmelden."
+                    , SoftBreak
+                    , Str "Dazu"
+                    , Space
+                    , Str "ben\246tigen"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "ihre"
+                    , Space
+                    , Str "HSBI-Zugangsdaten,"
+                    , Space
+                    , Str "mit"
+                    , Space
+                    , Str "denen"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "sich"
+                    , Space
+                    , Str "auch"
+                    , Space
+                    , Str "im"
+                    , Space
+                    , Quoted DoubleQuote [ Str "normalen" ]
+                    , Space
+                    , Str "ILIAS"
+                    , Space
+                    , Str "anmelden."
+                    ]
+                ]
+              ]
+          , Header
+              2
+              ( "bearbeitung-des-e-assessment" , [] , [] )
+              [ Str "Bearbeitung"
+              , Space
+              , Str "des"
+              , Space
+              , Str "E-Assessment"
+              ]
+          , OrderedList
+              ( 1 , Decimal , Period )
+              [ [ Para
+                    [ Str "Lesen"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "sich"
+                    , Space
+                    , Str "die"
+                    , Space
+                    , Str "Hinweise"
+                    , Space
+                    , Str "auf"
+                    , Space
+                    , Str "der"
+                    , Space
+                    , Str "Startseite"
+                    , Space
+                    , Str "durch"
+                    ]
+                ]
+              , [ Para
+                    [ Str "Bearbeiten"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "die"
+                    , Space
+                    , Str "Aufgaben"
+                    , Space
+                    , Str "in"
+                    , Space
+                    , Strong [ Str "einem" , Space , Str "einzigen" ]
+                    , Space
+                    , Str "Browser-Tab"
+                    ]
+                , Para
+                    [ Span
+                        ( "" , [ "alert" ] , [] )
+                        [ Strong
+                            [ Str "\214ffnen"
+                            , Space
+                            , Str "Sie"
+                            , Space
+                            , Str "die"
+                            , Space
+                            , Str "Aufgaben"
+                            , Space
+                            , Emph [ Str "NICHT" ]
+                            , Space
+                            , Str "in"
+                            , Space
+                            , Str "parallelen"
+                            , Space
+                            , Str "Tabs!"
+                            ]
+                        ]
+                    , SoftBreak
+                    , Str "Es"
+                    , Space
+                    , Str "kann"
+                    , Space
+                    , Str "sonst"
+                    , Space
+                    , Str "zu"
+                    , Space
+                    , Str "Fehlfunktionen"
+                    , Space
+                    , Str "von"
+                    , Space
+                    , Str "ILIAS"
+                    , Space
+                    , Str "kommen."
+                    ]
+                , Para
+                    [ Str "Bewegen"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "sich"
+                    , Space
+                    , Str "nicht"
+                    , Space
+                    , Str "per"
+                    , Space
+                    , Str "Browser-Navigation"
+                    , Space
+                    , Str "("
+                    , Quoted DoubleQuote [ Str "vor" ]
+                    , Str ","
+                    , Space
+                    , Quoted DoubleQuote [ Str "zur\252ck" ]
+                    , Space
+                    , Str "im"
+                    , Space
+                    , Str "Browser)"
+                    , SoftBreak
+                    , Str "durch"
+                    , Space
+                    , Str "die"
+                    , Space
+                    , Str "Aufgaben,"
+                    , Space
+                    , Str "sondern"
+                    , Space
+                    , Str "nutzen"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "daf\252r"
+                    , Space
+                    , Str "die"
+                    , Space
+                    , Str "Buttons"
+                    , Space
+                    , Quoted
+                        DoubleQuote
+                        [ Str "n\228chste" , Space , Str "Frage" ]
+                    , Str ","
+                    , SoftBreak
+                    , Quoted DoubleQuote [ Str "Weiter" ]
+                    , Space
+                    , Str "oder"
+                    , Space
+                    , Quoted DoubleQuote [ Str "Zur\252ck" ]
+                    , Space
+                    , Str "vom"
+                    , Space
+                    , Str "ILIAS!"
+                    ]
+                ]
+              , [ Para
+                    [ Str "Hinweis"
+                    , Space
+                    , Str "zu"
+                    , Space
+                    , Str "Anzeige"
+                    , Space
+                    , Str "der"
+                    , Space
+                    , Str "restlichen"
+                    , Space
+                    , Str "Bearbeitungsdauer"
+                    ]
+                , Para
+                    [ Str "Wenn"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "den"
+                    , Space
+                    , Str "Browser"
+                    , Space
+                    , Str "bzw."
+                    , Space
+                    , Str "das"
+                    , Space
+                    , Str "Tab"
+                    , Space
+                    , Str "mit"
+                    , Space
+                    , Str "der"
+                    , Space
+                    , Str "Pr\252fung"
+                    , Space
+                    , Str "im"
+                    , Space
+                    , Str "Laufe"
+                    , Space
+                    , Str "der"
+                    , Space
+                    , Str "Pr\252fung"
+                    , Space
+                    , Str "verlassen,"
+                    , SoftBreak
+                    , Str "wird"
+                    , Space
+                    , Str "Ihnen"
+                    , Space
+                    , Str "bei"
+                    , Space
+                    , Str "der"
+                    , Space
+                    , Str "R\252ckkehr"
+                    , Space
+                    , Str "unter"
+                    , Space
+                    , Str "Umst\228nden"
+                    , Space
+                    , Str "eine"
+                    , Space
+                    , Str "falsche"
+                    , Space
+                    , Str "restliche"
+                    , Space
+                    , Str "Bearbeitungsdauer"
+                    , SoftBreak
+                    , Str "angezeigt."
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "k\246nnen"
+                    , Space
+                    , Str "die"
+                    , Space
+                    , Str "Anzeige"
+                    , Space
+                    , Str "korrigieren/aktualisieren,"
+                    , Space
+                    , Str "indem"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "einfach"
+                    , Space
+                    , Str "zu"
+                    , Space
+                    , Str "einer"
+                    , SoftBreak
+                    , Str "vorigen"
+                    , Space
+                    , Str "oder"
+                    , Space
+                    , Str "n\228chsten"
+                    , Space
+                    , Str "Aufgabe"
+                    , Space
+                    , Str "navigieren."
+                    ]
+                , Para
+                    [ Str "Hinweis:"
+                    , Space
+                    , Str "Die"
+                    , Space
+                    , Str "restliche"
+                    , Space
+                    , Str "Bearbeitungsdauer"
+                    , Space
+                    , Str "wird"
+                    , Space
+                    , Str "im"
+                    , Space
+                    , Str "Test"
+                    , Space
+                    , Str "nur"
+                    , Space
+                    , Str "dann"
+                    , Space
+                    , Str "angezeigt,"
+                    , Space
+                    , Str "wenn"
+                    , Space
+                    , Str "diese"
+                    , SoftBreak
+                    , Str "Funktion"
+                    , Space
+                    , Str "von"
+                    , Space
+                    , Str "den"
+                    , Space
+                    , Str "Pr\252fenden"
+                    , Space
+                    , Str "aktiviert"
+                    , Space
+                    , Str "wurde."
+                    ]
+                ]
+              , [ Para
+                    [ Str "Parallel"
+                    , Space
+                    , Str "zum"
+                    , Space
+                    , Str "E-Assessment"
+                    , Space
+                    , Str "l\228uft"
+                    , Space
+                    , Str "eine"
+                    , Space
+                    , Str "Zoom-Session,"
+                    , Space
+                    , Str "dort"
+                    , Space
+                    , Str "k\246nnen"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "Fragen"
+                    , Space
+                    , Str "stellen"
+                    ]
+                , Para
+                    [ Str "Nur"
+                    , Space
+                    , Str "bei"
+                    , Space
+                    , Str "Durchf\252hrung"
+                    , Space
+                    , Str "aus"
+                    , Space
+                    , Str "dem"
+                    , Space
+                    , Str "Home-Office;"
+                    , Space
+                    , Str "Daten"
+                    , Space
+                    , Str "siehe"
+                    , Space
+                    , Str "Mail"
+                    , Space
+                    , Str "\252ber"
+                    , Space
+                    , Str "das"
+                    , Space
+                    , Str "LSF"
+                    , Space
+                    , Str "ca."
+                    , Space
+                    , Str "eine"
+                    , Space
+                    , Str "Woche"
+                    , Space
+                    , Str "vor"
+                    , Space
+                    , Str "der"
+                    , Space
+                    , Str "Pr\252fung"
+                    ]
+                ]
+              , [ Para
+                    [ Str "Verbindungsprobleme"
+                    , Space
+                    , Str "(Home-Office):"
+                    ]
+                , BulletList
+                    [ [ Plain
+                          [ Str "Bei"
+                          , Space
+                          , Str "kurzzeitigen"
+                          , Space
+                          , Str "Verbindungsabbr\252chen"
+                          , Space
+                          , Str "loggen"
+                          , Space
+                          , Str "Sie"
+                          , Space
+                          , Str "sich"
+                          , Space
+                          , Str "einfach"
+                          , Space
+                          , Str "wieder"
+                          , Space
+                          , Str "ein"
+                          ]
+                      ]
+                    , [ Plain
+                          [ Str "Wenn"
+                          , Space
+                          , Str "die"
+                          , Space
+                          , Str "Probleme"
+                          , Space
+                          , Str "l\228nger"
+                          , Space
+                          , Str "dauern,"
+                          , Space
+                          , Str "gilt"
+                          , Space
+                          , Str "der"
+                          , Space
+                          , Str "Versuch"
+                          , Space
+                          , Str "als"
+                          , Space
+                          , Str "nicht"
+                          , Space
+                          , Str "unternommen"
+                          , SoftBreak
+                          , Span
+                              ( "" , [ "notes" ] , [] )
+                              [ Str "(au\223er"
+                              , Space
+                              , Str "Sie"
+                              , Space
+                              , Str "haben"
+                              , Space
+                              , Str "die"
+                              , Space
+                              , Str "Probleme"
+                              , Space
+                              , Str "aktiv"
+                              , Space
+                              , Str "herbeigef\252hrt,"
+                              , Space
+                              , Str "dann"
+                              , Space
+                              , Str "kann"
+                              , Space
+                              , Str "das"
+                              , Space
+                              , Str "als"
+                              , SoftBreak
+                              , Str "T\228uschungsversuch"
+                              , Space
+                              , Str "gewertet"
+                              , Space
+                              , Str "werden,"
+                              , Space
+                              , Str "vgl."
+                              , Space
+                              , Str "RPO"
+                              , Space
+                              , Str "\167\&22a"
+                              , Space
+                              , Str "(4))"
+                              ]
+                          ]
+                      ]
+                    ]
+                ]
+              , [ Para
+                    [ Str "Erkl\228rung"
+                    , Space
+                    , Quoted
+                        DoubleQuote
+                        [ Str "Eigenst\228ndige"
+                        , Space
+                        , Str "Bearbeitung"
+                        ]
+                    , Space
+                    , Str "(max."
+                    , Space
+                    , Str "24h"
+                    , Space
+                    , Str "nach"
+                    , Space
+                    , Str "Pr\252fungsende)"
+                    ]
+                , Para
+                    [ Str "Sie"
+                    , Space
+                    , Str "m\252ssen"
+                    , Space
+                    , Str "eine"
+                    , Space
+                    , Str "Erkl\228rung"
+                    , Space
+                    , Str "der"
+                    , Space
+                    , Str "eigenst\228ndigen"
+                    , Space
+                    , Str "Bearbeitung"
+                    , Space
+                    , Str "in"
+                    , Space
+                    , Str "der"
+                    , Space
+                    , Str "vorbereiteten"
+                    , Space
+                    , Str "Aufgabe"
+                    , Space
+                    , Str "im"
+                    , Space
+                    , Str "separaten"
+                    , SoftBreak
+                    , Quoted DoubleQuote [ Str "Test" ]
+                    , Space
+                    , Str "im"
+                    , Space
+                    , Str "Pr\252fungsraum"
+                    , Space
+                    , Str "abgeben."
+                    , Space
+                    , Str "Ohne"
+                    , Space
+                    , Str "diese"
+                    , Space
+                    , Str "Erkl\228rung"
+                    , Space
+                    , Str "wird"
+                    , Space
+                    , Str "Ihre"
+                    , Space
+                    , Str "Pr\252fung"
+                    , Space
+                    , Str "nicht"
+                    , Space
+                    , Str "bearbeitet/gewertet!"
+                    ]
+                , Para
+                    [ Str "Dazu"
+                    , Space
+                    , Str "haben"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "maximal"
+                    , Space
+                    , Str "24"
+                    , Space
+                    , Str "Stunden"
+                    , Space
+                    , Str "nach"
+                    , Space
+                    , Str "Beendigung"
+                    , Space
+                    , Str "der"
+                    , Space
+                    , Str "Pr\252fung"
+                    , Space
+                    , Str "Zeit."
+                    ]
+                ]
+              ]
+          , Header
+              2
+              ( "fragetypen-demo" , [] , [] )
+              [ Str "Fragetypen-Demo" ]
+          , Para
+              [ Str "In"
+              , Space
+              , Str "Ihrem"
+              , Space
+              , Str "ILIAS-Kurs"
+              , Space
+              , Str "finden"
+              , Space
+              , Str "Sie"
+              , Space
+              , Str "eine"
+              , Space
+              , Str "Fragetypen-Demo"
+              , Space
+              , Str "mit"
+              , Space
+              , Str "den"
+              , Space
+              , Str "wichtigsten"
+              , Space
+              , Str "Fragetypen."
+              , Space
+              , Str "Machen"
+              , SoftBreak
+              , Str "Sie"
+              , Space
+              , Str "sich"
+              , Space
+              , Str "mit"
+              , Space
+              , Str "der"
+              , Space
+              , Str "Mechanik"
+              , Space
+              , Str "der"
+              , Space
+              , Str "Fragetypen"
+              , Space
+              , Str "vertraut"
+              , Space
+              , Str "und"
+              , Space
+              , Str "schauen"
+              , Space
+              , Str "Sie"
+              , Space
+              , Str "sich"
+              , Space
+              , Str "die"
+              , Space
+              , Str "Kommentare"
+              , Space
+              , Str "bei"
+              , SoftBreak
+              , Str "den"
+              , Space
+              , Str "einzelnen"
+              , Space
+              , Str "Aufgaben"
+              , Space
+              , Str "an."
+              , Space
+              , Str "Sie"
+              , Space
+              , Str "k\246nnen"
+              , Space
+              , Str "die"
+              , Space
+              , Str "Demo"
+              , Space
+              , Str "bei"
+              , Space
+              , Str "Bedarf"
+              , Space
+              , Str "beliebig"
+              , Space
+              , Str "oft"
+              , Space
+              , Str "wiederholen."
+              ]
+          , Header
+              2
+              ( "hinweise-zu-den-inhalten" , [] , [] )
+              [ Str "Hinweise"
+              , Space
+              , Str "zu"
+              , Space
+              , Str "den"
+              , Space
+              , Str "Inhalten"
+              ]
+          , BulletList
+              [ [ Plain
+                    [ Str "Klausurrelevant:"
+                    , Space
+                    , Str "Vorlesung"
+                    , Space
+                    , Str "und"
+                    , Space
+                    , Str "Praktikum"
+                    ]
+                ]
+              , [ Plain
+                    [ Str "F\252r"
+                    , Space
+                    , Str "Verst\228ndnis"
+                    , Space
+                    , Str "u.U."
+                    , Space
+                    , Str "hilfreich:"
+                    , Space
+                    , Str "Studium"
+                    , Space
+                    , Str "der"
+                    , Space
+                    , Str "vertiefenden"
+                    , Space
+                    , Str "Literaturangaben"
+                    ]
+                ]
+              ]
+          , RawBlock (Format "tex") "\\smallskip"
+          , BulletList
+              [ [ Plain [ Strong [ Str "Fragen" ] , Str ":" ]
+                , BulletList
+                    [ [ Plain
+                          [ Str "Schauen"
+                          , Space
+                          , Str "Sie"
+                          , Space
+                          , Str "sich"
+                          , Space
+                          , Str "die"
+                          , Space
+                          , Str "Quizzes"
+                          , Space
+                          , Str "an"
+                          , Space
+                          , Str "\8230"
+                          ]
+                      ]
+                    , [ Plain
+                          [ Str "Schauen"
+                          , Space
+                          , Str "Sie"
+                          , Space
+                          , Str "sich"
+                          , Space
+                          , Str "die"
+                          , Space
+                          , Str "Praktikumsaufgaben"
+                          , Space
+                          , Str "an"
+                          , Space
+                          , Str "\8230"
+                          ]
+                      ]
+                    , [ Plain
+                          [ Str "\220berlegen"
+                          , Space
+                          , Str "Sie"
+                          , Space
+                          , Str "sich,"
+                          , Space
+                          , Str "was"
+                          , Space
+                          , Str "zu"
+                          , Space
+                          , Str "einem"
+                          , Space
+                          , Str "Themengebiet"
+                          , Space
+                          , Str "im"
+                          , Space
+                          , Str "Rahmen"
+                          , Space
+                          , Str "einer"
+                          , Space
+                          , Str "Pr\252fung"
+                          , SoftBreak
+                          , Str "m\246glich"
+                          , Space
+                          , Str "ist"
+                          , Space
+                          , Str "und"
+                          , Space
+                          , Str "(wie)"
+                          , Space
+                          , Str "gefragt"
+                          , Space
+                          , Str "werden"
+                          , Space
+                          , Str "k\246nnte"
+                          , Space
+                          , Str ":)"
+                          ]
+                      ]
+                    ]
+                ]
+              ]
+          , Div
+              ( "" , [ "cbox" ] , [] )
+              [ Para
+                  [ Str "K\246nnen"
+                  , Space
+                  , Str "vor"
+                  , Space
+                  , Str "Kennen"
+                  , Space
+                  , Str ":-)"
+                  ]
+              ]
+          , Header
+              2
+              ( "beispiele-f\252r-m\246gliche-fragen" , [] , [] )
+              [ Str "Beispiele"
+              , Space
+              , Str "f\252r"
+              , Space
+              , Str "m\246gliche"
+              , Space
+              , Str "Fragen"
+              ]
+          , Header
+              3
+              ( "vererbung-und-polymorphie" , [] , [] )
+              [ Str "Vererbung"
+              , Space
+              , Str "und"
+              , Space
+              , Str "Polymorphie"
+              ]
+          , Para
+              [ Str "Betrachten"
+              , Space
+              , Str "Sie"
+              , Space
+              , Str "den"
+              , Space
+              , Str "folgenden"
+              , Space
+              , Str "Java-Code:"
+              ]
+          , CodeBlock
+              ( "" , [ "java" ] , [] )
+              "public class Person {\n    public String getInfo(Person p) { return \"Person\"; }\n}\n\npublic class Studi extends Person {\n    public String getInfo(Studi s) { return \"Studi\"; }\n\n    public static void main(String[] args) {\n        Studi s = new Studi(); Person p = s;\n        System.out.println(s.getInfo(p));\n        System.out.println(s.getInfo(s));\n    }\n}"
+          , Para
+              [ Str "Geben"
+              , Space
+              , Str "Sie"
+              , Space
+              , Str "alle"
+              , Space
+              , Str "Ausgaben,"
+              , Space
+              , Str "die"
+              , Space
+              , Str "das"
+              , Space
+              , Str "obige"
+              , Space
+              , Str "Programm"
+              , Space
+              , Str "produziert,"
+              , Space
+              , Str "an."
+              ]
+          , Para
+              [ Str "Begr\252nden"
+              , Space
+              , Str "Sie"
+              , Space
+              , Str "Ihre"
+              , Space
+              , Str "Antwort"
+              , Space
+              , Str "kurz"
+              , Space
+              , Str "und"
+              , Space
+              , Str "stichhaltig"
+              , Space
+              , Str "(f\252r"
+              , Space
+              , Emph [ Str "jede" ]
+              , Space
+              , Str "Ausgabe!)."
+              , SoftBreak
+              , Str "Was"
+              , Space
+              , Str "geschieht,"
+              , Space
+              , Str "bzw."
+              , Space
+              , Str "wieso"
+              , Space
+              , Str "kommt"
+              , Space
+              , Str "es"
+              , Space
+              , Str "zu"
+              , Space
+              , Str "der"
+              , Space
+              , Str "jeweiligen"
+              , Space
+              , Str "Ausgabe?"
+              ]
+          , Header
+              3
+              ( "multithreading-und-synchronisierung" , [] , [] )
+              [ Str "Multithreading"
+              , Space
+              , Str "und"
+              , Space
+              , Str "Synchronisierung"
+              ]
+          , CodeBlock
+              ( "" , [ "java" ] , [] )
+              "public class StaffelKaputt extends Thread {\n    private Object stab;\n    StaffelKaputt(Object stab) { this.stab = stab; }\n    public void run() {nimmStab(); laufen(); stabAbgeben();}\n    private void stabAbgeben() {\n        synchronized (stab) { stab.notifyAll(); }\n    }\n    private void nimmStab() {\n        synchronized (stab) {\n            try { stab.wait(); } catch (Exception e) { }\n        }}\n    void laufen() { System.out.println(\"laufe ... \"); }\n    public static void main(String[] args) {\n        Object stab = new Object();\n        StaffelKaputt l1 = new StaffelKaputt(stab);\n        StaffelKaputt l2 = new StaffelKaputt(stab);\n        l1.start(); l2.start();\n    }}"
+          , Para
+              [ Str "Das"
+              , Space
+              , Str "Programm"
+              , Space
+              , Str "enth\228lt"
+              , Space
+              , Str "einen"
+              , Space
+              , Str "Fehler,"
+              , Space
+              , Str "der"
+              , Space
+              , Str "sich"
+              , Space
+              , Str "zur"
+              , Space
+              , Str "Laufzeit"
+              , Space
+              , Str "offenbart."
+              , SoftBreak
+              , Str "Welche"
+              , Space
+              , Str "Ausgabe"
+              , Space
+              , Str "erwarten"
+              , Space
+              , Str "Sie"
+              , Space
+              , Str "(angenommen,"
+              , Space
+              , Str "das"
+              , Space
+              , Str "Programm"
+              , Space
+              , Str "w\228re"
+              , Space
+              , Str "fehlerfrei;"
+              , Space
+              , Str "eine"
+              , SoftBreak
+              , Str "m\246gliche"
+              , Space
+              , Str "Variante"
+              , Space
+              , Str "reicht)?"
+              , Space
+              , Str "Welche"
+              , Space
+              , Str "Ausgabe"
+              , Space
+              , Str "erhalten"
+              , Space
+              , Str "Sie"
+              , Space
+              , Str "stattdessen?"
+              , Space
+              , Str "Korrigieren"
+              , SoftBreak
+              , Str "Sie"
+              , Space
+              , Str "den"
+              , Space
+              , Str "Fehler."
+              ]
+          , Header
+              3
+              ( "regul\228re-ausdr\252cke" , [] , [] )
+              [ Str "Regul\228re" , Space , Str "Ausdr\252cke" ]
+          , Para
+              [ Str "Auf"
+              , Space
+              , Str "welche"
+              , Space
+              , Str "Strings"
+              , Space
+              , Str "passt"
+              , Space
+              , Str "(im"
+              , Space
+              , Str "Sinne"
+              , Space
+              , Str "von"
+              , Space
+              , Quoted DoubleQuote [ Str "match" ]
+              , Str ")"
+              , Space
+              , Str "der"
+              , Space
+              , Str "folgende"
+              , Space
+              , Str "regul\228re"
+              , SoftBreak
+              , Str "Ausdruck:"
+              , Space
+              , Code
+                  ( "" , [] , [] )
+                  "\\s*([a-zA-Z0-9_.\\-]+)\\s*=\\s*(-?\\d+\\.?\\d*)\\s;?\\s*"
+              ]
+          , Header
+              3
+              ( "versionieren-mit-git" , [] , [] )
+              [ Str "Versionieren"
+              , Space
+              , Str "mit"
+              , Space
+              , Str "Git"
+              ]
+          , BulletList
+              [ [ Para
+                    [ Str "Erkl\228ren"
+                    , Space
+                    , Str "Sie,"
+                    , Space
+                    , Str "wie"
+                    , Space
+                    , Str "man"
+                    , Space
+                    , Str "mit"
+                    , Space
+                    , Str "Git"
+                    , Space
+                    , Str "die"
+                    , Space
+                    , Str "Unterschiede"
+                    , Space
+                    , Str "zwischen"
+                    , Space
+                    , Str "zwei"
+                    , SoftBreak
+                    , Str "bestimmten"
+                    , Space
+                    , Str "Versionsst\228nden"
+                    , Space
+                    , Str "einer"
+                    , Space
+                    , Str "Datei"
+                    , Space
+                    , Str "herausfindet."
+                    ]
+                ]
+              , [ Para
+                    [ Str "Was"
+                    , Space
+                    , Str "ist"
+                    , Space
+                    , Str "der"
+                    , Space
+                    , Str "Unterschied"
+                    , Space
+                    , Str "zwischen"
+                    , Space
+                    , Str "einer"
+                    , Space
+                    , Str "Workingcopy"
+                    , Space
+                    , Str "und"
+                    , Space
+                    , Str "einem"
+                    , Space
+                    , Str "Repository?"
+                    ]
+                ]
+              , [ Para
+                    [ Str "Worin"
+                    , Space
+                    , Str "liegt"
+                    , Space
+                    , Str "der"
+                    , Space
+                    , Str "Unterschied"
+                    , Space
+                    , Str "zwischen"
+                    , Space
+                    , Str "folgenden"
+                    , Space
+                    , Str "Arbeitsschritten:"
+                    ]
+                , OrderedList
+                    ( 1 , LowerAlpha , Period )
+                    [ [ Plain
+                          [ Str "Editieren"
+                          , Space
+                          , Str "von"
+                          , Space
+                          , Str "Datei"
+                          , Space
+                          , Code ( "" , [] , [] ) "A.txt"
+                          ]
+                      ]
+                    , [ Plain [ Code ( "" , [] , [] ) "git add A.txt" ]
+                      ]
+                    , [ Plain
+                          [ Str "Editieren"
+                          , Space
+                          , Str "von"
+                          , Space
+                          , Str "Datei"
+                          , Space
+                          , Code ( "" , [] , [] ) "A.txt"
+                          ]
+                      ]
+                    , [ Plain [ Code ( "" , [] , [] ) "git commit" ] ]
+                    ]
+                , Para [ Str "versus" ]
+                , OrderedList
+                    ( 1 , LowerAlpha , Period )
+                    [ [ Plain
+                          [ Str "Editieren"
+                          , Space
+                          , Str "von"
+                          , Space
+                          , Str "Datei"
+                          , Space
+                          , Code ( "" , [] , [] ) "A.txt"
+                          ]
+                      ]
+                    , [ Plain
+                          [ Str "Editieren"
+                          , Space
+                          , Str "von"
+                          , Space
+                          , Str "Datei"
+                          , Space
+                          , Code ( "" , [] , [] ) "A.txt"
+                          ]
+                      ]
+                    , [ Plain [ Code ( "" , [] , [] ) "git add A.txt" ]
+                      ]
+                    , [ Plain [ Code ( "" , [] , [] ) "git commit" ] ]
+                    ]
+                ]
+              , [ Para
+                    [ Str "Was"
+                    , Space
+                    , Str "w\252rde"
+                    , Space
+                    , Code ( "" , [] , [] ) "git diff"
+                    , Space
+                    , Str "jeweils"
+                    , Space
+                    , Str "nach"
+                    , Space
+                    , Str "Schritt"
+                    , Space
+                    , Str "2"
+                    , Space
+                    , Str "anzeigen?"
+                    ]
+                ]
+              ]
+          , Header
+              3
+              ( "kommandozeilenparameter" , [] , [] )
+              [ Str "Kommandozeilenparameter" ]
+          , Para
+              [ Str "Schreiben"
+              , Space
+              , Str "Sie"
+              , Space
+              , Str "ein"
+              , Space
+              , Str "Programm,"
+              , Space
+              , Str "welches"
+              , Space
+              , Str "auf"
+              , Space
+              , Str "zwei"
+              , Space
+              , Str "Kommandozeilenparameter"
+              , Space
+              , Str "reagieren"
+              , SoftBreak
+              , Str "kann."
+              , Space
+              , Str "Die"
+              , Space
+              , Str "erkannten"
+              , Space
+              , Str "Parameter"
+              , Space
+              , Str "sollen"
+              , Space
+              , Str "auf"
+              , Space
+              , Str "der"
+              , Space
+              , Str "Konsole"
+              , Space
+              , Str "ausgegeben"
+              , Space
+              , Str "werden."
+              , Space
+              , Str "Nutzen"
+              , SoftBreak
+              , Str "Sie"
+              , Space
+              , Str "Apache"
+              , Space
+              , Str "Commons"
+              , Space
+              , Str "CLI"
+              , Space
+              , Str "(API"
+              , Space
+              , Str "siehe"
+              , Space
+              , Str "Anhang)."
+              ]
+          , BulletList
+              [ [ Plain
+                    [ Str "Beim"
+                    , Space
+                    , Str "Aufruf"
+                    , Space
+                    , Str "ohne"
+                    , Space
+                    , Str "Parameter"
+                    , Space
+                    , Str "soll"
+                    , Space
+                    , Str "eine"
+                    , Space
+                    , Str "Hilfe"
+                    , Space
+                    , Str "zum"
+                    , Space
+                    , Str "korrekten"
+                    , Space
+                    , Str "Aufruf"
+                    , Space
+                    , Str "ausgegeben"
+                    , SoftBreak
+                    , Str "werden"
+                    , Space
+                    , Str "und"
+                    , Space
+                    , Str "das"
+                    , Space
+                    , Str "Programm"
+                    , Space
+                    , Str "soll"
+                    , Space
+                    , Str "sich"
+                    , Space
+                    , Str "anschlie\223end"
+                    , Space
+                    , Str "beenden."
+                    ]
+                ]
+              , [ Plain
+                    [ Str "Das"
+                    , Space
+                    , Str "Programm"
+                    , Space
+                    , Str "soll"
+                    , Space
+                    , Str "den"
+                    , Space
+                    , Str "Parameter"
+                    , Space
+                    , Code ( "" , [] , [] ) "-debug"
+                    , Space
+                    , Str "erkennen."
+                    ]
+                ]
+              , [ Plain
+                    [ Str "Das"
+                    , Space
+                    , Str "Programm"
+                    , Space
+                    , Str "soll"
+                    , Space
+                    , Str "den"
+                    , Space
+                    , Str "Parameter"
+                    , Space
+                    , Code ( "" , [] , [] ) "-x=10"
+                    , Space
+                    , Str "erkennen,"
+                    , Space
+                    , Str "wobei"
+                    , Space
+                    , Str "der"
+                    , Space
+                    , Str "Wert"
+                    , Space
+                    , Str "beim"
+                    , Space
+                    , Str "Aufruf"
+                    , SoftBreak
+                    , Str "variieren"
+                    , Space
+                    , Str "kann"
+                    , Space
+                    , Str "(Integer)."
+                    ]
+                ]
+              , [ Plain
+                    [ Str "Die"
+                    , Space
+                    , Str "Parameter"
+                    , Space
+                    , Str "k\246nnen"
+                    , Space
+                    , Str "in"
+                    , Space
+                    , Str "unterschiedlicher"
+                    , Space
+                    , Str "Reihenfolge"
+                    , Space
+                    , Str "auftreten."
+                    ]
+                ]
+              , [ Plain
+                    [ Str "Es"
+                    , Space
+                    , Str "kann"
+                    , Space
+                    , Str "auch"
+                    , Space
+                    , Str "nur"
+                    , Space
+                    , Str "ein"
+                    , Space
+                    , Str "Parameter"
+                    , Space
+                    , Str "angegeben"
+                    , Space
+                    , Str "werden."
+                    ]
+                ]
+              ]
+          , Header
+              3
+              ( "build-mit-ant" , [] , [] )
+              [ Str "Build" , Space , Str "mit" , Space , Str "Ant" ]
+          , BulletList
+              [ [ Plain
+                    [ Str "Was"
+                    , Space
+                    , Str "ist"
+                    , Space
+                    , Str "der"
+                    , Space
+                    , Str "Unterschied"
+                    , Space
+                    , Str "zwischen"
+                    , Space
+                    , Str "Ant-Targets"
+                    , Space
+                    , Str "und"
+                    , Space
+                    , Str "Ant-Tasks?"
+                    ]
+                ]
+              , [ Plain
+                    [ Str "Wie"
+                    , Space
+                    , Str "kann"
+                    , Space
+                    , Str "man"
+                    , Space
+                    , Str "Ant-Properties"
+                    , Space
+                    , Str "von"
+                    , Space
+                    , Str "au\223en"
+                    , Space
+                    , Str "(beim"
+                    , Space
+                    , Str "Aufruf)"
+                    , Space
+                    , Str "setzen?"
+                    ]
+                ]
+              , [ Plain
+                    [ Str "Schreiben"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "ein"
+                    , Space
+                    , Str "Ant-Target,"
+                    , Space
+                    , Str "welches"
+                    , Space
+                    , Str "alle"
+                    , Space
+                    , Code ( "" , [] , [] ) ".class"
+                    , Str "-Dateien"
+                    , Space
+                    , Str "in"
+                    , Space
+                    , Str "einem"
+                    , Space
+                    , Str "Ordner"
+                    , SoftBreak
+                    , Str "umbenennt."
+                    ]
+                ]
+              , [ Plain
+                    [ Str "Schreiben"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "ein"
+                    , Space
+                    , Str "Ant-Target,"
+                    , Space
+                    , Str "mit"
+                    , Space
+                    , Str "dem"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "die"
+                    , Space
+                    , Str "Javadoc-Dokumentation"
+                    , SoftBreak
+                    , Str "erzeugen,"
+                    , Space
+                    , Str "packen"
+                    , Space
+                    , Str "und"
+                    , Space
+                    , Str "das"
+                    , Space
+                    , Str "resultierende"
+                    , Space
+                    , Code ( "" , [] , [] ) ".zip"
+                    , Str "-File"
+                    , Space
+                    , Str "in"
+                    , Space
+                    , Str "den"
+                    , Space
+                    , Str "Ordner"
+                    , Space
+                    , Code ( "" , [] , [] ) "dist/"
+                    , SoftBreak
+                    , Str "verschieben."
+                    ]
+                ]
+              , [ Plain
+                    [ Str "Schreiben"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "Ant-Targets,"
+                    , Space
+                    , Str "mit"
+                    , Space
+                    , Str "denen"
+                    , Space
+                    , Str "Sie"
+                    , Space
+                    , Str "JUnit-Testf\228lle"
+                    , Space
+                    , Str "ausf\252hren"
+                    , Space
+                    , Str "und"
+                    , SoftBreak
+                    , Str "auswerten"
+                    , Space
+                    , Str "k\246nnen."
+                    ]
+                ]
+              ]
+          , Header 3 ( "generics" , [] , [] ) [ Str "Generics" ]
+          , Para
+              [ Str "Was"
+              , Space
+              , Str "kommt"
+              , Space
+              , Str "hier"
+              , Space
+              , Str "raus?"
+              , Space
+              , Str "Und"
+              , Space
+              , Str "warum?"
+              ]
+          , CodeBlock
+              ( "" , [ "java" ] , [] )
+              "public class X {\n    void methode(int a) {\n        System.out.println(\"non-generic\");\n    }\n    <T> void methode(T a) {\n        System.out.println(\"generisch\");\n    }\n    public static void main(String[] args) {\n        X x = new X();\n        x.methode(3);\n        x.methode(new Integer(4));\n        x.methode(\"huhu\");\n    }\n}"
+          , Header 3 ( "logging" , [] , [] ) [ Str "Logging" ]
+          , Para
+              [ Str "Erkl\228ren"
+              , Space
+              , Str "Sie"
+              , Space
+              , Str "den"
+              , Space
+              , Str "Code."
+              , Space
+              , Str "Was"
+              , Space
+              , Str "passiert?"
+              ]
+          , CodeBlock
+              ( "" , [ "java" ] , [] )
+              "class MyFormatter extends SimpleFormatter {\n    public String format(LogRecord record) {\n        return super.format(record) + \"---- FAKE ----\\n\";\n    }\n}\npublic class MoreLogging {\n    public static void main(String[] argv) {\n        Logger l = Logger.getLogger(\"MoreLogging\");\n        l.setLevel(Level.FINE);\n\n        ConsoleHandler myHandler = new ConsoleHandler();\n        myHandler.setFormatter(new MyFormatter());\n        myHandler.setLevel(Level.FINER);\n        l.addHandler(myHandler);\n\n        l.info(\"Hello World :-)\");\n        l.fine(\"fine\");\n        l.finer(\"finer\");\n        l.finest(\"finest\");\n    }\n}"
+          , Header
+              3
+              ( "methodenreferenzen" , [] , [] )
+              [ Str "Methodenreferenzen" ]
+          , BulletList
+              [ [ Para
+                    [ Str "Was"
+                    , Space
+                    , Str "bedeutet"
+                    , Space
+                    , Str "der"
+                    , Space
+                    , Str "folgende"
+                    , Space
+                    , Str "Code?"
+                    ]
+                , CodeBlock
+                    ( "" , [ "java" ] , [] )
+                    "List<String> str = Arrays.asList(\"a\", \"b\", \"A\", \"B\");\nstr.sort(String::compareToIgnoreCase);"
+                ]
+              ]
+          , RawBlock
+              (Format "html")
+              "<!-- DO NOT REMOVE - THIS IS A LAST SLIDE TO INDICATE THE LICENSE AND POSSIBLE EXCEPTIONS (IMAGES, ...). -->"
+          , Div
+              ( "" , [ "slides" ] , [] )
+              [ Header 2 ( "license" , [] , [] ) [ Str "LICENSE" ]
+              , Para
+                  [ Image
+                      ( "" , [] , [] )
+                      []
+                      ( "https://licensebuttons.net/l/by-sa/4.0/88x31.png"
+                      , ""
+                      )
+                  ]
+              , Para
+                  [ Str "Unless"
+                  , Space
+                  , Str "otherwise"
+                  , Space
+                  , Str "noted,"
+                  , Space
+                  , Str "this"
+                  , Space
+                  , Str "work"
+                  , Space
+                  , Str "is"
+                  , Space
+                  , Str "licensed"
+                  , Space
+                  , Str "under"
+                  , Space
+                  , Str "CC"
+                  , Space
+                  , Str "BY-SA"
+                  , Space
+                  , Str "4.0."
+                  ]
+              ]
+          , Para []
+          ]
+        ]
+    ]
+]

--- a/filters/test filter/subdir/file-d.md
+++ b/filters/test filter/subdir/file-d.md
@@ -2,4 +2,8 @@
 
 Wuppie!
 
+***
+
 [link to ../orga/grading](../orga/grading.md)
+
+***

--- a/filters/test filter/summary.md
+++ b/filters/test filter/summary.md
@@ -1,0 +1,76 @@
+---
+author: me
+title: Thesis
+---
+
+# Summary.md
+
+## This should work
+
+Thanks everyone!
+
+***
+
+[File A](file-a.md)
+
+***
+
+![Image A (from Readme.md)](img/a.png)
+
+![](img/a.png)
+
+
+## Different (wrong) format
+
+-   [wrong extension](file-c.png)
+-   [not local](https://pandoc.org/lua-filters.html)
+-   [still not local](https://pandoc.org/lua-filters.md)
+-   [also not local](http://pandoc.org/lua-filters.md)
+-   [not there and not here](wuppie.md)
+
+***
+
+since our filter works for `pandoc.Para` only, let's put these links into a paragraph:
+[not there and not here](wuppie.md) and [still not local](https://pandoc.org/lua-filters.md).
+
+***
+
+## Recursive inclusion
+
+***
+
+[Subdir: File D](subdir/file-d.md)
+
+***
+
+[Subdir: Readme](subdir/leaf/readme.md)
+
+***
+
+::: slides
+## Hidden Parts
+
+This part will be visible while building the makefile dependencies, but will be removed for building
+the website because of being marked as slides content. We can use this to include files in the build
+process even if we do not want to have explicit links in the site ...
+
+Use case: We want to use a Hugo-generated schedule, i.e. we do not provide links to all individual
+lections in this readme or elsewhere, but need to define the scope of the semester/offering. So all
+links to the lectures to be included can go here and will be hidden in the generated website. The
+referenced pages will be available in the site, however.
+
+This itemize will not be recognized and included:
+
+-   [Syllabus](orga/syllabus.md)
+-   [Ressourcen](orga/resources.md)
+-   [Prüfungsvorbereitung](orga/exams.md)
+
+But this will because of the new lines between each item:
+
+-   [Syllabus](orga/syllabus.md)
+
+-   [Ressourcen](orga/resources.md)
+
+-   [Prüfungsvorbereitung](orga/exams.md)
+
+:::


### PR DESCRIPTION
include-mdfiles.lua – filter to include local Markdown files via links

```
for each link to local Markdown file in start document:
    (1) read file
    (2) "fix" links to local images, i.e. prepend include path
    (3) process links to local Markdown files in paragraphs and include content (recursively)
        - foreach Para:
            - prepare new empty block list (result), add new current block (empty Para)
            - foreach inline in current Para:
                - if not link: append inline to current block's content
                - if link:
                    - read link.target (file), process content and append resulting blocks to block list
                    - add new current block (empty Para) for remaining inlines of current block
            - return block list to replace current Para

```

**warning: this won't handle endless recursion!**