### PR TITLE
[Filter] add credits to 'include-files' (makedeps, include-md)

### DIFF
--- a/filters/hugo_makedeps.lua
+++ b/filters/hugo_makedeps.lua
@@ -98,6 +98,12 @@ Examples:
     pandoc -L hugo_makedeps.lua -t markdown readme.md
 
 
+Credits: Work on this filter was partially inspired by some ideas shared in "include-files"
+(https://github.com/pandoc/lua-filters/blob/master/include-files/include-files.lua, by Albert
+Krewinkel (@tarleb), license: MIT). The 'hugo_makedeps.lua' filter has been developed by us
+from scratch and is neither based on nor contains any third-party code.
+
+
 Caveats:
 (a) All referenced Markdown files must have UNIQUE NAMES.
 (b) References to the top index page (landing page) are (presumably) not working.

--- a/filters/include-mdfiles.lua
+++ b/filters/include-mdfiles.lua
@@ -22,6 +22,12 @@ Examples:
     pandoc -L include-mdfiles.lua -t markdown summary.md
 
 
+Credits: Work on this filter was partially inspired by some ideas shared in "include-files"
+(https://github.com/pandoc/lua-filters/blob/master/include-files/include-files.lua, by Albert
+Krewinkel (@tarleb), license: MIT). The 'include-mdfiles.lua' filter has been developed by us
+from scratch and is neither based on nor contains any third-party code.
+
+
 Caveats:
 The same file cannot be included more than once to avoid potential endless recursion.
 ]]--


### PR DESCRIPTION
Credits: Work on 'include-mdfiles.lua' and 'hugo_makedeps.lua' was partially inspired by some ideas shared in "include-files" (https://github.com/pandoc/lua-filters/blob/master/include-files/include-files.lua, by Albert Krewinkel (@tarleb), license: MIT). The 'include-mdfiles.lua' and 'hugo_makedeps.lua' filter have been developed by us from scratch and is neither based on nor contains any third-party code.
