### PR TITLE
[Filter] refactor and allow 'hugo_makedeps.lua' to work with files in subdirs

### DIFF
--- a/filters/hugo_makedeps.lua
+++ b/filters/hugo_makedeps.lua
@@ -298,8 +298,12 @@ function Pandoc (doc)
     INDEX_MD = doc.meta.indexMD or "readme"             -- we do need the name w/o extension
     ROOT = pandoc.system.get_working_directory()        -- remember our project root
 
+    -- get filename (input file)
+    local input_files = PANDOC_STATE.input_files
+    local file = #input_files >= 1 and input_files[#input_files] or "."
+
     -- landing page: process all images and links
-    _process_doc(doc.blocks, INDEX_MD, ".")
+    _handle_file(file)
 
     -- process files recursively: breadth-first search
     local target = _dequeue()

--- a/filters/hugo_makedeps.lua
+++ b/filters/hugo_makedeps.lua
@@ -239,7 +239,7 @@ local function _filter_blocks_in_dir (blocks, target)
                     _remember_file(include_path, md_file, newl)
 
                     -- enqueue local landing page "include_path/readme.md" for later processing
-                    _enqueue(_old_path(include_path, INDEX_MD .. ".md"))
+                    _enqueue(_prepend_include_path(INDEX_MD .. ".md"))
 
                     -- collect and enqueue all new images and links in this file 'include_path/md_file'
                     local collect_images_links = {
@@ -252,7 +252,7 @@ local function _filter_blocks_in_dir (blocks, target)
                         Link = function (link)
                             if _is_local_markdown_file_link(link) then
                                 -- enqueue "include_path/link.target" for later processing
-                                _enqueue(_old_path(include_path, link.target))
+                                _enqueue(_prepend_include_path(link.target))
                             end
                         end
                     }

--- a/filters/hugo_makedeps.lua
+++ b/filters/hugo_makedeps.lua
@@ -92,10 +92,11 @@ images and local links to Markdown files. For each such link, this process will 
 (recursively, via breadth-first search).
 
 
-Usage: This filter is intended to be used with individual files that are placed directly in
-the working directory.
+Usage: This filter is intended to be used with individual files that are placed either directly
+in the working directory or in a subdirectory.
 Examples:
     pandoc -L hugo_makedeps.lua -t markdown readme.md
+    pandoc -L hugo_makedeps.lua -t markdown subdir/leaf/readme.md
 
 
 Credits: Work on this filter was partially inspired by some ideas shared in "include-files"
@@ -104,7 +105,7 @@ Krewinkel (@tarleb), license: MIT). The 'hugo_makedeps.lua' filter has been deve
 from scratch and is neither based on nor contains any third-party code.
 
 
-Caveats:
+Caveats (see 'hugo_rewritelinks.lua'):
 (a) All referenced Markdown files must have UNIQUE NAMES.
 (b) References to the top index page (landing page) are (presumably) not working.
 ]]--

--- a/filters/hugo_rewritelinks.lua
+++ b/filters/hugo_rewritelinks.lua
@@ -37,7 +37,7 @@ Examples:
     pandoc -L hugo_rewritelinks.lua -t markdown test/subdir/leaf/foo.md
 
 
-Caveats:
+Caveats (see 'hugo_makedeps.lua'):
 (a) All referenced Markdown files must have UNIQUE NAMES.
 (b) References to the top index page (landing page) are (presumably) not working.
 ]]--

--- a/filters/include_mdfiles.lua
+++ b/filters/include_mdfiles.lua
@@ -54,7 +54,7 @@ end
 
 local function _prepend_include_path (path)
     local include_path = pandoc.path.make_relative(pandoc.system.get_working_directory(), ROOT)
-    return pandoc.path.normalize(pandoc.path.join({include_path, path}))
+    return pandoc.path.normalize(pandoc.path.join({ include_path, path }))
 end
 
 

--- a/filters/test/Makefile
+++ b/filters/test/Makefile
@@ -2,7 +2,9 @@ DIFF ?= diff --strip-trailing-cr -u
 PANDOC ?= pandoc
 
 FILES_TRANSFORM  = readme.md
-FILES_MAKEDEPS   = readme.md
+FILES_MAKEDEPS1  = readme.md
+FILES_MAKEDEPS2  = subdir/readme.md
+FILES_MAKEDEPS3  = subdir/leaf/readme.md
 FILES_INCLUDEMD1 = summary.md
 FILES_INCLUDEMD2 = readme.md
 FILES_INCLUDEMD3 = subdir/readme.md
@@ -16,33 +18,37 @@ LUA_INCLUDEMD    = ../include_mdfiles.lua
 test: test_rewritelinks test_makedeps test_includemd
 
 test_rewritelinks: $(FILES_TRANSFORM)
-	@$(PANDOC) -L $(LUA_REWRITELINKS) -t native $^                                        \
+	@$(PANDOC) -L $(LUA_REWRITELINKS) -t native $^                                                     \
 	    | $(DIFF) expected_rewritelinks1.native -
-	@$(PANDOC) -L $(LUA_REWRITELINKS) -M indexMD="foo" -t native $^                       \
+	@$(PANDOC) -L $(LUA_REWRITELINKS) -M indexMD="foo" -t native $^                                    \
 	    | $(DIFF) expected_rewritelinks2.native -
-	@$(PANDOC) -L $(LUA_REWRITELINKS) -M indexMD="readme" -t native $^                    \
+	@$(PANDOC) -L $(LUA_REWRITELINKS) -M indexMD="readme" -t native $^                                 \
 	    | $(DIFF) expected_rewritelinks3.native -
-	@$(PANDOC) -L $(LUA_REWRITELINKS) -M weight=42 -M indexMD="readme" -t native $^       \
+	@$(PANDOC) -L $(LUA_REWRITELINKS) -M weight=42 -M indexMD="readme" -t native $^                    \
 	    | $(DIFF) expected_rewritelinks4.native -
 
-test_makedeps: $(FILES_MAKEDEPS)
-	@$(PANDOC) -L $(LUA_MAKEDEPS) -t native $^                                            \
+test_makedeps: $(FILES_MAKEDEPS1) $(FILES_MAKEDEPS2) $(FILES_MAKEDEPS3)
+	@$(PANDOC) -L $(LUA_MAKEDEPS) -t native $(FILES_MAKEDEPS1)                                         \
 	    | $(DIFF) expected_makedeps1.native -
-	@$(PANDOC) -L $(LUA_MAKEDEPS) -M indexMD="foo" -t native $^                           \
+	@$(PANDOC) -L $(LUA_MAKEDEPS) -M indexMD="foo" -t native $(FILES_MAKEDEPS1)                        \
 	    | $(DIFF) expected_makedeps2.native -
-	@$(PANDOC) -L $(LUA_MAKEDEPS) -M indexMD="readme" -t native $^                        \
+	@$(PANDOC) -L $(LUA_MAKEDEPS) -M indexMD="readme" -t native $(FILES_MAKEDEPS1)                     \
 	    | $(DIFF) expected_makedeps3.native -
-	@$(PANDOC) -L $(LUA_MAKEDEPS) -M prefix="foobar" -M indexMD="readme" -t native $^     \
+	@$(PANDOC) -L $(LUA_MAKEDEPS) -M prefix="foobar" -M indexMD="readme" -t native $(FILES_MAKEDEPS1)  \
 	    | $(DIFF) expected_makedeps4.native -
+	@$(PANDOC) -L $(LUA_MAKEDEPS) -t native $(FILES_MAKEDEPS2)                                         \
+	    | $(DIFF) expected_makedeps5.native -
+	@$(PANDOC) -L $(LUA_MAKEDEPS) -t native $(FILES_MAKEDEPS3)                                         \
+	    | $(DIFF) expected_makedeps6.native -
 
 test_includemd: $(FILES_INCLUDEMD1) $(FILES_INCLUDEMD2) $(FILES_INCLUDEMD3) $(FILES_INCLUDEMD4)
-	@$(PANDOC) -L $(LUA_INCLUDEMD) -t native $(FILES_INCLUDEMD1)                          \
+	@$(PANDOC) -L $(LUA_INCLUDEMD) -t native $(FILES_INCLUDEMD1)                                       \
 	    | $(DIFF) expected_inludemd1.native -
-	@$(PANDOC) -L $(LUA_INCLUDEMD) -t native $(FILES_INCLUDEMD2)                          \
+	@$(PANDOC) -L $(LUA_INCLUDEMD) -t native $(FILES_INCLUDEMD2)                                       \
 	    | $(DIFF) expected_inludemd2.native -
-	@$(PANDOC) -L $(LUA_INCLUDEMD) -t native $(FILES_INCLUDEMD3)                          \
+	@$(PANDOC) -L $(LUA_INCLUDEMD) -t native $(FILES_INCLUDEMD3)                                       \
 	    | $(DIFF) expected_inludemd3.native -
-	@$(PANDOC) -L $(LUA_INCLUDEMD) -t native $(FILES_INCLUDEMD4)                          \
+	@$(PANDOC) -L $(LUA_INCLUDEMD) -t native $(FILES_INCLUDEMD4)                                       \
 	    | $(DIFF) expected_inludemd4.native -
 
 
@@ -56,15 +62,19 @@ expected_rewritelinks3.native: $(FILES_TRANSFORM)
 expected_rewritelinks4.native: $(FILES_TRANSFORM)
 	$(PANDOC) -L $(LUA_REWRITELINKS) -M weight=42 -M indexMD="readme" -t native -o $@ $^
 
-expected: expected_makedeps1.native expected_makedeps2.native expected_makedeps3.native expected_makedeps4.native
-expected_makedeps1.native: $(FILES_MAKEDEPS)
+expected: expected_makedeps1.native expected_makedeps2.native expected_makedeps3.native expected_makedeps4.native expected_makedeps5.native expected_makedeps6.native
+expected_makedeps1.native: $(FILES_MAKEDEPS1)
 	$(PANDOC) -L $(LUA_MAKEDEPS) -t native -o $@ $^
-expected_makedeps2.native: $(FILES_MAKEDEPS)
+expected_makedeps2.native: $(FILES_MAKEDEPS1)
 	$(PANDOC) -L $(LUA_MAKEDEPS) -M indexMD="foo" -t native -o $@ $^
-expected_makedeps3.native: $(FILES_MAKEDEPS)
+expected_makedeps3.native: $(FILES_MAKEDEPS1)
 	$(PANDOC) -L $(LUA_MAKEDEPS) -M indexMD="readme" -t native -o $@ $^
-expected_makedeps4.native: $(FILES_MAKEDEPS)
+expected_makedeps4.native: $(FILES_MAKEDEPS1)
 	$(PANDOC) -L $(LUA_MAKEDEPS) -M prefix="foobar" -M indexMD="readme" -t native -o $@ $^
+expected_makedeps5.native: $(FILES_MAKEDEPS2)
+	$(PANDOC) -L $(LUA_MAKEDEPS) -t native -o $@ $^
+expected_makedeps6.native: $(FILES_MAKEDEPS3)
+	$(PANDOC) -L $(LUA_MAKEDEPS) -t native -o $@ $^
 
 expected: expected_inludemd1.native expected_inludemd2.native expected_inludemd3.native expected_inludemd4.native
 expected_inludemd1.native: $(FILES_INCLUDEMD1)
@@ -79,7 +89,7 @@ expected_inludemd4.native: $(FILES_INCLUDEMD4)
 
 clean:
 	rm -rf expected_rewritelinks1.native expected_rewritelinks2.native expected_rewritelinks3.native expected_rewritelinks4.native
-	rm -rf expected_makedeps1.native expected_makedeps2.native expected_makedeps3.native expected_makedeps4.native
+	rm -rf expected_makedeps1.native expected_makedeps2.native expected_makedeps3.native expected_makedeps4.native expected_makedeps5.native expected_makedeps6.native
 	rm -rf expected_inludemd1.native expected_inludemd2.native expected_inludemd3.native expected_inludemd4.native
 
 .PHONY: test test_rewritelinks test_makedeps test_includemd expected clean

--- a/filters/test/expected_makedeps2.native
+++ b/filters/test/expected_makedeps2.native
@@ -1,7 +1,7 @@
 [ Plain
-    [ RawInline (Format "markdown") "a.png: img/a.png\n"
+    [ RawInline (Format "markdown") "readme/a.png: img/a.png\n"
     , RawInline
-        (Format "markdown") "WEB_IMAGE_TARGETS += a.png\n\n"
+        (Format "markdown") "WEB_IMAGE_TARGETS += readme/a.png\n\n"
     , RawInline (Format "markdown") "file-b/a.png: img/a.png\n"
     , RawInline
         (Format "markdown") "WEB_IMAGE_TARGETS += file-b/a.png\n\n"
@@ -23,9 +23,6 @@
     , RawInline
         (Format "markdown")
         "WEB_IMAGE_TARGETS += subdir/readme/c.png\n\n"
-    , RawInline (Format "markdown") "readme/a.png: img/a.png\n"
-    , RawInline
-        (Format "markdown") "WEB_IMAGE_TARGETS += readme/a.png\n\n"
     , RawInline
         (Format "markdown")
         "orga/syllabus/modulbeschreibung.png: orga/img/modulbeschreibung.png\n"
@@ -46,11 +43,15 @@
         "WEB_IMAGE_TARGETS += subdir/leaf/bar/d.png\n\n"
     ]
 , Plain
-    [ RawInline (Format "markdown") "_index.md: foo.md\n"
-    , RawInline (Format "markdown") "_index.md: a.png\n"
-    , RawInline (Format "markdown") "_index.md: WEIGHT=1\n"
+    [ RawInline
+        (Format "markdown") "readme/_index.md: readme.md\n"
     , RawInline
-        (Format "markdown") "WEB_MARKDOWN_TARGETS += _index.md\n\n"
+        (Format "markdown") "readme/_index.md: readme/a.png\n"
+    , RawInline
+        (Format "markdown") "readme/_index.md: WEIGHT=1\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += readme/_index.md\n\n"
     , RawInline
         (Format "markdown") "file-a/_index.md: file-a.md\n"
     , RawInline
@@ -109,22 +110,13 @@
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += subdir/readme/_index.md\n\n"
     , RawInline
-        (Format "markdown") "readme/_index.md: readme.md\n"
-    , RawInline
-        (Format "markdown") "readme/_index.md: readme/a.png\n"
-    , RawInline
-        (Format "markdown") "readme/_index.md: WEIGHT=8\n"
-    , RawInline
-        (Format "markdown")
-        "WEB_MARKDOWN_TARGETS += readme/_index.md\n\n"
-    , RawInline
         (Format "markdown")
         "orga/syllabus/_index.md: orga/syllabus.md\n"
     , RawInline
         (Format "markdown")
         "orga/syllabus/_index.md: orga/syllabus/modulbeschreibung.png\n"
     , RawInline
-        (Format "markdown") "orga/syllabus/_index.md: WEIGHT=9\n"
+        (Format "markdown") "orga/syllabus/_index.md: WEIGHT=8\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += orga/syllabus/_index.md\n\n"
@@ -132,14 +124,14 @@
         (Format "markdown")
         "orga/resources/_index.md: orga/resources.md\n"
     , RawInline
-        (Format "markdown") "orga/resources/_index.md: WEIGHT=10\n"
+        (Format "markdown") "orga/resources/_index.md: WEIGHT=9\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += orga/resources/_index.md\n\n"
     , RawInline
         (Format "markdown") "orga/exams/_index.md: orga/exams.md\n"
     , RawInline
-        (Format "markdown") "orga/exams/_index.md: WEIGHT=11\n"
+        (Format "markdown") "orga/exams/_index.md: WEIGHT=10\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += orga/exams/_index.md\n\n"
@@ -147,7 +139,7 @@
         (Format "markdown")
         "orga/grading/_index.md: orga/grading.md\n"
     , RawInline
-        (Format "markdown") "orga/grading/_index.md: WEIGHT=12\n"
+        (Format "markdown") "orga/grading/_index.md: WEIGHT=11\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += orga/grading/_index.md\n\n"
@@ -158,7 +150,7 @@
         (Format "markdown")
         "subdir/leaf/bar/_index.md: subdir/leaf/bar/b.png subdir/leaf/bar/d.png\n"
     , RawInline
-        (Format "markdown") "subdir/leaf/bar/_index.md: WEIGHT=13\n"
+        (Format "markdown") "subdir/leaf/bar/_index.md: WEIGHT=12\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += subdir/leaf/bar/_index.md\n\n"

--- a/filters/test/expected_makedeps5.native
+++ b/filters/test/expected_makedeps5.native
@@ -1,0 +1,75 @@
+[ Plain
+    [ RawInline
+        (Format "markdown") "subdir/c.png: subdir/img/c.png\n"
+    , RawInline
+        (Format "markdown") "WEB_IMAGE_TARGETS += subdir/c.png\n\n"
+    , RawInline
+        (Format "markdown")
+        "subdir/leaf/foo/b.png: subdir/leaf/img/b.png\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_IMAGE_TARGETS += subdir/leaf/foo/b.png\n\n"
+    , RawInline
+        (Format "markdown")
+        "subdir/leaf/b.png: subdir/leaf/img/b.png\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_IMAGE_TARGETS += subdir/leaf/b.png\n\n"
+    , RawInline
+        (Format "markdown")
+        "subdir/leaf/bar/b.png: subdir/leaf/img/b.png\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_IMAGE_TARGETS += subdir/leaf/bar/b.png\n\n"
+    , RawInline
+        (Format "markdown")
+        "subdir/leaf/bar/d.png: subdir/leaf/img/d.png\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_IMAGE_TARGETS += subdir/leaf/bar/d.png\n\n"
+    ]
+, Plain
+    [ RawInline
+        (Format "markdown") "subdir/_index.md: subdir/readme.md\n"
+    , RawInline
+        (Format "markdown") "subdir/_index.md: subdir/c.png\n"
+    , RawInline
+        (Format "markdown") "subdir/_index.md: WEIGHT=1\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += subdir/_index.md\n\n"
+    , RawInline
+        (Format "markdown")
+        "subdir/leaf/foo/_index.md: subdir/leaf/foo.md\n"
+    , RawInline
+        (Format "markdown")
+        "subdir/leaf/foo/_index.md: subdir/leaf/foo/b.png\n"
+    , RawInline
+        (Format "markdown") "subdir/leaf/foo/_index.md: WEIGHT=2\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += subdir/leaf/foo/_index.md\n\n"
+    , RawInline
+        (Format "markdown")
+        "subdir/leaf/_index.md: subdir/leaf/readme.md\n"
+    , RawInline
+        (Format "markdown")
+        "subdir/leaf/_index.md: subdir/leaf/b.png\n"
+    , RawInline
+        (Format "markdown") "subdir/leaf/_index.md: WEIGHT=3\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += subdir/leaf/_index.md\n\n"
+    , RawInline
+        (Format "markdown")
+        "subdir/leaf/bar/_index.md: subdir/leaf/bar.md\n"
+    , RawInline
+        (Format "markdown")
+        "subdir/leaf/bar/_index.md: subdir/leaf/bar/b.png subdir/leaf/bar/d.png\n"
+    , RawInline
+        (Format "markdown") "subdir/leaf/bar/_index.md: WEIGHT=4\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += subdir/leaf/bar/_index.md\n\n"
+    ]
+]

--- a/filters/test/expected_makedeps6.native
+++ b/filters/test/expected_makedeps6.native
@@ -1,0 +1,22 @@
+[ Plain
+    [ RawInline
+        (Format "markdown")
+        "subdir/leaf/b.png: subdir/leaf/img/b.png\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_IMAGE_TARGETS += subdir/leaf/b.png\n\n"
+    ]
+, Plain
+    [ RawInline
+        (Format "markdown")
+        "subdir/leaf/_index.md: subdir/leaf/readme.md\n"
+    , RawInline
+        (Format "markdown")
+        "subdir/leaf/_index.md: subdir/leaf/b.png\n"
+    , RawInline
+        (Format "markdown") "subdir/leaf/_index.md: WEIGHT=1\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += subdir/leaf/_index.md\n\n"
+    ]
+]


### PR DESCRIPTION
this changes should enable something like `pandoc -L hugo_makedeps.lua -t markdown subdir/leaf/readme.md`.

fixes #141
