### PR TITLE
Filter: Allow "warping", i.e. to remove folder parts (makedeps)

### DIFF
--- a/examples/hugo-lecture/Makefile
+++ b/examples/hugo-lecture/Makefile
@@ -54,6 +54,9 @@ HUGO_LOCAL = $(wildcard local.yaml)
 INDEX_MD   = readme
 ROOT_DOC   = $(INDEX_MD).md
 
+## String to be removed from target path, e.g. 'markdown'
+WARP_DIR   =
+
 #--------------------------------------------------------------------------------
 # Tools
 #--------------------------------------------------------------------------------
@@ -139,7 +142,7 @@ WEIGHT                  =
 WEB_IMAGE_TARGETS       =
 
 $(ROOT_DEPS): $(ROOT_DOC)
-	@$(PANDOC) $(PANDOC_ARGS) -L hugo_makedeps.lua -M prefix=$(TEMP_DIR) -M indexMD=$(INDEX_MD) -f markdown -t markdown $< -o $@
+	@$(PANDOC) $(PANDOC_ARGS) -L hugo_makedeps.lua -M indexMD=$(INDEX_MD) -M prefix=$(TEMP_DIR) -M warp=$(WARP_DIR) -f markdown -t markdown $< -o $@
 -include $(ROOT_DEPS)
 
 #--------------------------------------------------------------------------------
@@ -245,8 +248,8 @@ $(WEB_IMAGE_TARGETS):
 ## Hugo: Process markdown with pandoc (preprocessing for hugo)
 $(WEB_MARKDOWN_TARGETS):
 	$(create-folder)
-	$(PANDOC) $(PANDOC_ARGS)  -L hugo_rewritelinks.lua -s  -d hugo -M weight=$(WEIGHT) -M indexMD=$(INDEX_MD) -M prefix=$(TEMP_DIR) $< -o $@
-#	$(PANDOC) $(PANDOC_ARGS) -d hugo -M weight=$(WEIGHT) -M indexMD=$(INDEX_MD) -M prefix=$(TEMP_DIR) $< -o $@
+	$(PANDOC) $(PANDOC_ARGS)  -L hugo_rewritelinks.lua -s  -d hugo -M weight=$(WEIGHT) -M indexMD=$(INDEX_MD) $< -o $@
+#	$(PANDOC) $(PANDOC_ARGS) -d hugo -M weight=$(WEIGHT) -M indexMD=$(INDEX_MD) $< -o $@
 
 ## Slides: Generate pdf slides
 ## Folder structure and names: path/name.md, path/<images>/, path_name.pdf

--- a/filters/hugo_makedeps.lua
+++ b/filters/hugo_makedeps.lua
@@ -204,7 +204,7 @@ local function _new_path (parent, file)
     local path = _prepend_include_path(name)
 
     -- remove folder names if requested, e.g. remove 'markdown/' from the path 'include_path/(md_file?)'
-    if WARP then
+    if WARP and WARP ~= "" then
         path = path:gsub(WARP.."/", "")
     end
 

--- a/filters/hugo_makedeps.lua
+++ b/filters/hugo_makedeps.lua
@@ -133,7 +133,7 @@ WEB_IMAGE_TARGETS += PREFIX/file-a/c.png
 In this example we "remove" the subfolder 'subfolder' from the target hierarchy. Since the readme
 in this level would now overwrite the readme in the parent level, it will be skipped - as will all
 files in 'subfolder' with the same name as those in the parent level! Also potential links in
-'subfolder/readme.md' will not be analysed and considered!
+'subfolder/readme.md' and other skipped files will not be analysed and considered!
 
 
 Usage: This filter is intended to be used with individual files that are placed either directly

--- a/filters/hugo_makedeps.lua
+++ b/filters/hugo_makedeps.lua
@@ -133,7 +133,8 @@ WEB_IMAGE_TARGETS += PREFIX/file-a/c.png
 In this example we "remove" the subfolder 'subfolder' from the target hierarchy. Since the readme
 in this level would now overwrite the readme in the parent level, it will be skipped - as will all
 files in 'subfolder' with the same name as those in the parent level! Also potential links in
-'subfolder/readme.md' and other skipped files will not be analysed and considered!
+'subfolder/readme.md' and other skipped files will not be analysed and considered! Subsequently,
+the build with Hugo can fail as the links are still in the files but the linked-to files are missing.
 
 
 Usage: This filter is intended to be used with individual files that are placed either directly

--- a/filters/hugo_makedeps.lua
+++ b/filters/hugo_makedeps.lua
@@ -191,8 +191,6 @@ local function _remember_file (old_target, new_target)
     if not links[new_target] then
         weights[#weights + 1] = new_target
         links[new_target] = old_target      -- store new target as key because due to the "remove path parts" functionality the same resulting new file name can be constructed from different markdown files - we just keep the FIRST occurrence (n old_target => 1 new_target)
-    else
-        io.stderr:write("\t (_remember_file) WARNING: new path '" .. new_target .. "' (from '" .. old_target .. "') has been already processed ... THIS SHOULD NOT HAPPEN ... \n")
     end
 end
 

--- a/filters/hugo_makedeps.lua
+++ b/filters/hugo_makedeps.lua
@@ -158,7 +158,7 @@ local function _new_path (parent, file)
     local name = (parent == INDEX_MD) and "." or parent
     local path = _prepend_include_path(name)
 
-    -- remove folder names if requested, e.g. remove 'markdown/' from the path
+    -- remove folder names if requested, e.g. remove 'markdown/' from the path 'include_path/(md_file?)'
     if WARP then
         path = path:gsub(WARP.."/", "")
     end

--- a/filters/test/Makefile
+++ b/filters/test/Makefile
@@ -40,6 +40,10 @@ test_makedeps: $(FILES_MAKEDEPS1) $(FILES_MAKEDEPS2) $(FILES_MAKEDEPS3)
 	    | $(DIFF) expected_makedeps5.native -
 	@$(PANDOC) -L $(LUA_MAKEDEPS) -t native $(FILES_MAKEDEPS3)                                         \
 	    | $(DIFF) expected_makedeps6.native -
+	@$(PANDOC) -L $(LUA_MAKEDEPS) -M warp="subdir" -t native $(FILES_MAKEDEPS1)                        \
+	    | $(DIFF) expected_makedeps7.native -
+	@$(PANDOC) -L $(LUA_MAKEDEPS) -M warp="leaf" -t native $(FILES_MAKEDEPS1)                          \
+	    | $(DIFF) expected_makedeps8.native -
 
 test_includemd: $(FILES_INCLUDEMD1) $(FILES_INCLUDEMD2) $(FILES_INCLUDEMD3) $(FILES_INCLUDEMD4)
 	@$(PANDOC) -L $(LUA_INCLUDEMD) -t native $(FILES_INCLUDEMD1)                                       \
@@ -62,7 +66,7 @@ expected_rewritelinks3.native: $(FILES_TRANSFORM)
 expected_rewritelinks4.native: $(FILES_TRANSFORM)
 	$(PANDOC) -L $(LUA_REWRITELINKS) -M weight=42 -M indexMD="readme" -t native -o $@ $^
 
-expected: expected_makedeps1.native expected_makedeps2.native expected_makedeps3.native expected_makedeps4.native expected_makedeps5.native expected_makedeps6.native
+expected: expected_makedeps1.native expected_makedeps2.native expected_makedeps3.native expected_makedeps4.native expected_makedeps5.native expected_makedeps6.native expected_makedeps7.native expected_makedeps8.native
 expected_makedeps1.native: $(FILES_MAKEDEPS1)
 	$(PANDOC) -L $(LUA_MAKEDEPS) -t native -o $@ $^
 expected_makedeps2.native: $(FILES_MAKEDEPS1)
@@ -75,6 +79,10 @@ expected_makedeps5.native: $(FILES_MAKEDEPS2)
 	$(PANDOC) -L $(LUA_MAKEDEPS) -t native -o $@ $^
 expected_makedeps6.native: $(FILES_MAKEDEPS3)
 	$(PANDOC) -L $(LUA_MAKEDEPS) -t native -o $@ $^
+expected_makedeps7.native: $(FILES_MAKEDEPS1)
+	$(PANDOC) -L $(LUA_MAKEDEPS) -M warp="subdir" -t native -o $@ $^
+expected_makedeps8.native: $(FILES_MAKEDEPS1)
+	$(PANDOC) -L $(LUA_MAKEDEPS) -M warp="leaf" -t native -o $@ $^
 
 expected: expected_inludemd1.native expected_inludemd2.native expected_inludemd3.native expected_inludemd4.native
 expected_inludemd1.native: $(FILES_INCLUDEMD1)
@@ -89,7 +97,7 @@ expected_inludemd4.native: $(FILES_INCLUDEMD4)
 
 clean:
 	rm -rf expected_rewritelinks1.native expected_rewritelinks2.native expected_rewritelinks3.native expected_rewritelinks4.native
-	rm -rf expected_makedeps1.native expected_makedeps2.native expected_makedeps3.native expected_makedeps4.native expected_makedeps5.native expected_makedeps6.native
+	rm -rf expected_makedeps1.native expected_makedeps2.native expected_makedeps3.native expected_makedeps4.native expected_makedeps5.native expected_makedeps6.native expected_makedeps7.native expected_makedeps8.native
 	rm -rf expected_inludemd1.native expected_inludemd2.native expected_inludemd3.native expected_inludemd4.native
 
 .PHONY: test test_rewritelinks test_makedeps test_includemd expected clean

--- a/filters/test/expected_makedeps7.native
+++ b/filters/test/expected_makedeps7.native
@@ -1,0 +1,152 @@
+[ Plain
+    [ RawInline (Format "markdown") "a.png: img/a.png\n"
+    , RawInline
+        (Format "markdown") "WEB_IMAGE_TARGETS += a.png\n\n"
+    , RawInline (Format "markdown") "file-b/a.png: img/a.png\n"
+    , RawInline
+        (Format "markdown") "WEB_IMAGE_TARGETS += file-b/a.png\n\n"
+    , RawInline
+        (Format "markdown") "file-e/c.png: subdir/img/c.png\n"
+    , RawInline
+        (Format "markdown") "WEB_IMAGE_TARGETS += file-e/c.png\n\n"
+    , RawInline
+        (Format "markdown")
+        "leaf/foo/b.png: subdir/leaf/img/b.png\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_IMAGE_TARGETS += leaf/foo/b.png\n\n"
+    , RawInline
+        (Format "markdown")
+        "orga/syllabus/modulbeschreibung.png: orga/img/modulbeschreibung.png\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_IMAGE_TARGETS += orga/syllabus/modulbeschreibung.png\n\n"
+    , RawInline
+        (Format "markdown")
+        "leaf/bar/b.png: subdir/leaf/img/b.png\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_IMAGE_TARGETS += leaf/bar/b.png\n\n"
+    , RawInline
+        (Format "markdown")
+        "leaf/bar/d.png: subdir/leaf/img/d.png\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_IMAGE_TARGETS += leaf/bar/d.png\n\n"
+    , RawInline
+        (Format "markdown") "leaf/b.png: subdir/leaf/img/b.png\n"
+    , RawInline
+        (Format "markdown") "WEB_IMAGE_TARGETS += leaf/b.png\n\n"
+    ]
+, Plain
+    [ RawInline (Format "markdown") "_index.md: readme.md\n"
+    , RawInline (Format "markdown") "_index.md: a.png\n"
+    , RawInline (Format "markdown") "_index.md: WEIGHT=1\n"
+    , RawInline
+        (Format "markdown") "WEB_MARKDOWN_TARGETS += _index.md\n\n"
+    , RawInline
+        (Format "markdown") "file-a/_index.md: file-a.md\n"
+    , RawInline
+        (Format "markdown") "file-a/_index.md: WEIGHT=2\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += file-a/_index.md\n\n"
+    , RawInline
+        (Format "markdown") "file-b/_index.md: file-b.md\n"
+    , RawInline
+        (Format "markdown") "file-b/_index.md: file-b/a.png\n"
+    , RawInline
+        (Format "markdown") "file-b/_index.md: WEIGHT=3\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += file-b/_index.md\n\n"
+    , RawInline
+        (Format "markdown") "file-d/_index.md: subdir/file-d.md\n"
+    , RawInline
+        (Format "markdown") "file-d/_index.md: WEIGHT=4\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += file-d/_index.md\n\n"
+    , RawInline
+        (Format "markdown") "file-e/_index.md: subdir/file-e.md\n"
+    , RawInline
+        (Format "markdown") "file-e/_index.md: file-e/c.png\n"
+    , RawInline
+        (Format "markdown") "file-e/_index.md: WEIGHT=5\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += file-e/_index.md\n\n"
+    , RawInline
+        (Format "markdown")
+        "leaf/foo/_index.md: subdir/leaf/foo.md\n"
+    , RawInline
+        (Format "markdown") "leaf/foo/_index.md: leaf/foo/b.png\n"
+    , RawInline
+        (Format "markdown") "leaf/foo/_index.md: WEIGHT=6\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += leaf/foo/_index.md\n\n"
+    , RawInline
+        (Format "markdown")
+        "orga/syllabus/_index.md: orga/syllabus.md\n"
+    , RawInline
+        (Format "markdown")
+        "orga/syllabus/_index.md: orga/syllabus/modulbeschreibung.png\n"
+    , RawInline
+        (Format "markdown") "orga/syllabus/_index.md: WEIGHT=7\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += orga/syllabus/_index.md\n\n"
+    , RawInline
+        (Format "markdown")
+        "orga/resources/_index.md: orga/resources.md\n"
+    , RawInline
+        (Format "markdown") "orga/resources/_index.md: WEIGHT=8\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += orga/resources/_index.md\n\n"
+    , RawInline
+        (Format "markdown") "orga/exams/_index.md: orga/exams.md\n"
+    , RawInline
+        (Format "markdown") "orga/exams/_index.md: WEIGHT=9\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += orga/exams/_index.md\n\n"
+    , RawInline
+        (Format "markdown")
+        "orga/grading/_index.md: orga/grading.md\n"
+    , RawInline
+        (Format "markdown") "orga/grading/_index.md: WEIGHT=10\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += orga/grading/_index.md\n\n"
+    , RawInline
+        (Format "markdown")
+        "leaf/bar/_index.md: subdir/leaf/bar.md\n"
+    , RawInline
+        (Format "markdown")
+        "leaf/bar/_index.md: leaf/bar/b.png leaf/bar/d.png\n"
+    , RawInline
+        (Format "markdown") "leaf/bar/_index.md: WEIGHT=11\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += leaf/bar/_index.md\n\n"
+    , RawInline
+        (Format "markdown")
+        "leaf/_index.md: subdir/leaf/readme.md\n"
+    , RawInline
+        (Format "markdown") "leaf/_index.md: leaf/b.png\n"
+    , RawInline
+        (Format "markdown") "leaf/_index.md: WEIGHT=12\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += leaf/_index.md\n\n"
+    , RawInline
+        (Format "markdown") "orga/_index.md: orga/readme.md\n"
+    , RawInline
+        (Format "markdown") "orga/_index.md: WEIGHT=13\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += orga/_index.md\n\n"
+    ]
+]

--- a/filters/test/expected_makedeps8.native
+++ b/filters/test/expected_makedeps8.native
@@ -1,0 +1,157 @@
+[ Plain
+    [ RawInline (Format "markdown") "a.png: img/a.png\n"
+    , RawInline
+        (Format "markdown") "WEB_IMAGE_TARGETS += a.png\n\n"
+    , RawInline (Format "markdown") "file-b/a.png: img/a.png\n"
+    , RawInline
+        (Format "markdown") "WEB_IMAGE_TARGETS += file-b/a.png\n\n"
+    , RawInline
+        (Format "markdown")
+        "subdir/file-e/c.png: subdir/img/c.png\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_IMAGE_TARGETS += subdir/file-e/c.png\n\n"
+    , RawInline
+        (Format "markdown")
+        "subdir/foo/b.png: subdir/leaf/img/b.png\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_IMAGE_TARGETS += subdir/foo/b.png\n\n"
+    , RawInline
+        (Format "markdown") "subdir/c.png: subdir/img/c.png\n"
+    , RawInline
+        (Format "markdown") "WEB_IMAGE_TARGETS += subdir/c.png\n\n"
+    , RawInline
+        (Format "markdown")
+        "orga/syllabus/modulbeschreibung.png: orga/img/modulbeschreibung.png\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_IMAGE_TARGETS += orga/syllabus/modulbeschreibung.png\n\n"
+    , RawInline
+        (Format "markdown")
+        "subdir/bar/b.png: subdir/leaf/img/b.png\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_IMAGE_TARGETS += subdir/bar/b.png\n\n"
+    , RawInline
+        (Format "markdown")
+        "subdir/bar/d.png: subdir/leaf/img/d.png\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_IMAGE_TARGETS += subdir/bar/d.png\n\n"
+    ]
+, Plain
+    [ RawInline (Format "markdown") "_index.md: readme.md\n"
+    , RawInline (Format "markdown") "_index.md: a.png\n"
+    , RawInline (Format "markdown") "_index.md: WEIGHT=1\n"
+    , RawInline
+        (Format "markdown") "WEB_MARKDOWN_TARGETS += _index.md\n\n"
+    , RawInline
+        (Format "markdown") "file-a/_index.md: file-a.md\n"
+    , RawInline
+        (Format "markdown") "file-a/_index.md: WEIGHT=2\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += file-a/_index.md\n\n"
+    , RawInline
+        (Format "markdown") "file-b/_index.md: file-b.md\n"
+    , RawInline
+        (Format "markdown") "file-b/_index.md: file-b/a.png\n"
+    , RawInline
+        (Format "markdown") "file-b/_index.md: WEIGHT=3\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += file-b/_index.md\n\n"
+    , RawInline
+        (Format "markdown")
+        "subdir/file-d/_index.md: subdir/file-d.md\n"
+    , RawInline
+        (Format "markdown") "subdir/file-d/_index.md: WEIGHT=4\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += subdir/file-d/_index.md\n\n"
+    , RawInline
+        (Format "markdown")
+        "subdir/file-e/_index.md: subdir/file-e.md\n"
+    , RawInline
+        (Format "markdown")
+        "subdir/file-e/_index.md: subdir/file-e/c.png\n"
+    , RawInline
+        (Format "markdown") "subdir/file-e/_index.md: WEIGHT=5\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += subdir/file-e/_index.md\n\n"
+    , RawInline
+        (Format "markdown")
+        "subdir/foo/_index.md: subdir/leaf/foo.md\n"
+    , RawInline
+        (Format "markdown")
+        "subdir/foo/_index.md: subdir/foo/b.png\n"
+    , RawInline
+        (Format "markdown") "subdir/foo/_index.md: WEIGHT=6\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += subdir/foo/_index.md\n\n"
+    , RawInline
+        (Format "markdown") "subdir/_index.md: subdir/readme.md\n"
+    , RawInline
+        (Format "markdown") "subdir/_index.md: subdir/c.png\n"
+    , RawInline
+        (Format "markdown") "subdir/_index.md: WEIGHT=7\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += subdir/_index.md\n\n"
+    , RawInline
+        (Format "markdown")
+        "orga/syllabus/_index.md: orga/syllabus.md\n"
+    , RawInline
+        (Format "markdown")
+        "orga/syllabus/_index.md: orga/syllabus/modulbeschreibung.png\n"
+    , RawInline
+        (Format "markdown") "orga/syllabus/_index.md: WEIGHT=8\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += orga/syllabus/_index.md\n\n"
+    , RawInline
+        (Format "markdown")
+        "orga/resources/_index.md: orga/resources.md\n"
+    , RawInline
+        (Format "markdown") "orga/resources/_index.md: WEIGHT=9\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += orga/resources/_index.md\n\n"
+    , RawInline
+        (Format "markdown") "orga/exams/_index.md: orga/exams.md\n"
+    , RawInline
+        (Format "markdown") "orga/exams/_index.md: WEIGHT=10\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += orga/exams/_index.md\n\n"
+    , RawInline
+        (Format "markdown")
+        "orga/grading/_index.md: orga/grading.md\n"
+    , RawInline
+        (Format "markdown") "orga/grading/_index.md: WEIGHT=11\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += orga/grading/_index.md\n\n"
+    , RawInline
+        (Format "markdown")
+        "subdir/bar/_index.md: subdir/leaf/bar.md\n"
+    , RawInline
+        (Format "markdown")
+        "subdir/bar/_index.md: subdir/bar/b.png subdir/bar/d.png\n"
+    , RawInline
+        (Format "markdown") "subdir/bar/_index.md: WEIGHT=12\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += subdir/bar/_index.md\n\n"
+    , RawInline
+        (Format "markdown") "orga/_index.md: orga/readme.md\n"
+    , RawInline
+        (Format "markdown") "orga/_index.md: WEIGHT=13\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += orga/_index.md\n\n"
+    ]
+]


### PR DESCRIPTION
Using the filter "hugo_makedeps.lua" we can transform a preview-friendly folder/file structure (e.g., preview in GitHub, VSCode, Obsidian) into a structure suitable for Hugo. 

However, we keep the original folder structure. All folders become a folder in the menu generated by Hugo. In some cases, however, this is not desirable.

Consider the following structure:

```
.
|____readme.md
|____admin/
|____homework/
|____lecture/
| |____topic_a
| | |____lession1.md
| | |____lession2.md
| |____topic_b
| | |____lession3.md
| | |____lession4.md
| | |____lession5.md
```

This would lead to a menu containing the entries "admin", "homework" and "lecture". Since "admin" and "homework" are usually hidden (accessible only via direct links), this would lead to a single toplevel entry "lecture". In this case it would be much desirable to skip the folder "lecture" and to promote the content (i.e. the topics in this example) as toplevel menu entries.

This PR introduces a "warping" feature. Using the metadata field `warp` the filter will remove this part from the generated target paths. A `pandoc -L hugo_makedeps.lua -M warp="lecture" -t markdown readme.md` will remove the part "lecture" from the generated Makefile targets, so that "topic_a", "topic_b", ... will be on the same level as "homework" and "admin".

WARNING: In this example we "remove" the subfolder 'lecture' from the target hierarchy. Since the readme in this level would now overwrite the readme in the parent level, it will be skipped - as will all files in 'lecture' with the same name as those in the parent level! Also potential links in 'lecture/readme.md' and other skipped files will not be analysed and considered! Subsequently, the build with Hugo can fail as the links are still in the files but the linked-to files are missing.
