### PR TITLE
Pandoc: downgrading to 3.1.6.1 due to issues in URL handling in 3.1.6.2

### DIFF
--- a/docker/install-pandoc.sh
+++ b/docker/install-pandoc.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 ## Versions
-export PANDOC="3.1.6.2"
+export PANDOC="3.1.6.1"
 # set ARCH="amd64" or ARCH="arm64" externally
 export ARCH="${ARCH:-amd64}"  # if not set, use 'amd64' as default
 


### PR DESCRIPTION
see https://github.com/jgm/pandoc/issues/9014