### PR TITLE
Examples: disable tex and dot target per default

### DIFF
--- a/examples/hugo-lecture/Makefile
+++ b/examples/hugo-lecture/Makefile
@@ -234,12 +234,14 @@ $(READINGS): $(BIBTEX)
 	$(PANDOC) -s -f biblatex -t markdown $< -o $@
 
 ## Aux: Create images from tex files
-$(TEX_TARGETS): %.png: %.tex
-	$(LATEX) $(LATEX_ARGS) $(notdir $<)
+## uncomment to convert .tex to .png
+#$(TEX_TARGETS): %.png: %.tex
+#	$(LATEX) $(LATEX_ARGS) $(notdir $<)
 
 ## Aux: Create images from dot files
-$(DOT_TARGETS): %.png: %.dot
-	$(DOT) $(DOT_ARGS) $< -o $@
+## uncomment to convert .dot to .png
+#$(DOT_TARGETS): %.png: %.dot
+#	$(DOT) $(DOT_ARGS) $< -o $@
 
 ## Hugo: Copy image files to $(TEMP_DIR)
 $(WEB_IMAGE_TARGETS):


### PR DESCRIPTION
Sometimes the calculated paths and targets (web/pdf vs. tex and/or dot) overlap, so the wrong target springs into action. We do need the tex and dot targets only in certain cases to produce a .png from a .dot or .tex - but this will be done manually. So disabling these auxiliary targets will avoid those mismatches ...