### PR TITLE
Filter: makedeps: enqueue _all_ intermediate landing pages and do this earlier in the process

### DIFF
--- a/filters/hugo_makedeps.lua
+++ b/filters/hugo_makedeps.lua
@@ -176,6 +176,7 @@ local WARP = nil                -- string to be removed from path, e.g. 'markdow
 local ROOT = "."                -- absolute path to working directory when starting
 local LEVEL_STARTFILE = nil     -- remember subdir(s) of landing page/start file
 
+
 -- helper
 local function _is_local_path (path)
     return pandoc.path.is_relative(path) and    -- is relative path

--- a/filters/hugo_makedeps.lua
+++ b/filters/hugo_makedeps.lua
@@ -284,7 +284,7 @@ local function _filter_blocks_in_dir (blocks, target)
             pandoc.path.directory(target),    -- may still contain '../'
             function ()
                 -- when processing the start file: remember the level of it's subdir(s) relative to project root
-                -- "a/b/readme.md" => remember "a/b" to avoid trying to include 'readme.md' files above this level (except directly linked)
+                -- "a/b/readme.md" => remember "a/b" to avoid trying to include 'readme.md' files above this level (except when directly linked to)
                 if LEVEL_STARTFILE == nil then
                     LEVEL_STARTFILE = _prepend_include_path(".")
                 end

--- a/filters/hugo_makedeps.lua
+++ b/filters/hugo_makedeps.lua
@@ -201,7 +201,7 @@ local function _new_path (parent, file)
     -- append the file name of path 'parent' as last folder to the current include path
     -- when handling 'readme.md', we just get the current include path
     local parent, _ = pandoc.path.split_extension(pandoc.path.filename(parent))
-    local name = (parent == INDEX_MD) and "." or parent
+    local name = (parent == INDEX_MD) and "" or parent
     local path = _prepend_include_path(name)
 
     -- remove folder names if requested, e.g. remove 'markdown/' from the path 'include_path/(md_file?)'
@@ -350,7 +350,7 @@ function Pandoc (doc)
 
     -- get filename (input file)
     local input_files = PANDOC_STATE.input_files
-    local file = #input_files >= 1 and input_files[#input_files] or "."
+    local file = #input_files >= 1 and input_files[#input_files] or ""
 
     -- enqueue landing page for processing
     _enqueue(_prepend_include_path(file))

--- a/filters/hugo_makedeps.lua
+++ b/filters/hugo_makedeps.lua
@@ -174,7 +174,7 @@ local INDEX_MD = "readme"       -- name of readme.md (will be set from metadata)
 local PREFIX = "."              -- string to prepend to the new locations, e.g. temporary folder (will be set from metadata)
 local WARP = nil                -- string to be removed from path, e.g. 'markdown'
 local ROOT = "."                -- absolute path to working directory when starting
-
+local LEVEL_STARTFILE = nil     -- remember subdir(s) of landing page/start file
 
 -- helper
 local function _is_local_path (path)
@@ -201,7 +201,7 @@ local function _new_path (parent, file)
     -- append the file name of path 'parent' as last folder to the current include path
     -- when handling 'readme.md', we just get the current include path
     local parent, _ = pandoc.path.split_extension(pandoc.path.filename(parent))
-    local name = (parent == INDEX_MD) and "" or parent
+    local name = (parent == INDEX_MD) and "." or parent
     local path = _prepend_include_path(name)
 
     -- remove folder names if requested, e.g. remove 'markdown/' from the path 'include_path/(md_file?)'
@@ -238,6 +238,19 @@ local function _dequeue ()
     return path
 end
 
+-- enqueue local landing page(s) of current target for later processing ("include_path/readme.md")
+local function _enqueue_landingpages (target)
+    -- if target = 'a/b/c/d/foo.md' and the start file was 'a/b/readme.md', we should consider only the 'c/d/' part here
+    local path = pandoc.path.directory(pandoc.path.make_relative(target, LEVEL_STARTFILE))
+
+    -- do this for all sub-folders in path, i.e. for a path 'a/b/c' enqueue 'a/b/c/readme.md', 'a/b/readme.md',
+    -- and 'a/readme.md'; do not enqueue 'readme.md' to save time: the start file has been processed already
+    while path ~= "." do
+        _enqueue(pandoc.path.normalize(pandoc.path.join({ LEVEL_STARTFILE, path, INDEX_MD .. ".md" })))
+        path = pandoc.path.directory(path)      -- removes the last directory separator and everything after
+    end
+end
+
 
 -- store for each processed file the old and the new path
 local function _remember_file (old_target, new_target)
@@ -269,6 +282,12 @@ local function _filter_blocks_in_dir (blocks, target)
     pandoc.system.with_working_directory(
             pandoc.path.directory(target),    -- may still contain '../'
             function ()
+                -- when processing the start file: remember the level of it's subdir(s) relative to project root
+                -- "a/b/readme.md" => remember "a/b" to avoid trying to include 'readme.md' files above this level (except directly linked)
+                if LEVEL_STARTFILE == nil then
+                    LEVEL_STARTFILE = _prepend_include_path(".")
+                end
+
                 -- same as 'pandoc.path.directory(target)' but w/o '../' since Pandoc cd'ed here
                 local old_target = _prepend_include_path(pandoc.path.filename(target))  -- old link: include_path/target
                 local new_target = _new_path(target, "_index.md")                       -- new link: PREFIX/include_path/(md_file?)/_index.md
@@ -277,9 +296,6 @@ local function _filter_blocks_in_dir (blocks, target)
                 if not links[new_target] then
                     -- remember this file (path w/o '../')
                     _remember_file(old_target, new_target)
-
-                    -- enqueue local landing page of current path for later processing ("include_path/readme.md")
-                    _enqueue(_prepend_include_path(INDEX_MD .. ".md"))
 
                     -- collect and enqueue all new images and links in current file 'include_path/target'
                     blocks:walk({
@@ -290,7 +306,9 @@ local function _filter_blocks_in_dir (blocks, target)
                         end,
                         Link = function (link)
                             if _is_local_markdown_file_link(link) then
-                                _enqueue(_prepend_include_path(link.target))
+                                local target = _prepend_include_path(link.target)
+                                _enqueue_landingpages(target)
+                                _enqueue(target)
                             end
                         end
                     })
@@ -350,7 +368,7 @@ function Pandoc (doc)
 
     -- get filename (input file)
     local input_files = PANDOC_STATE.input_files
-    local file = #input_files >= 1 and input_files[#input_files] or ""
+    local file = #input_files >= 1 and input_files[#input_files] or "."
 
     -- enqueue landing page for processing
     _enqueue(_prepend_include_path(file))

--- a/filters/hugo_makedeps.lua
+++ b/filters/hugo_makedeps.lua
@@ -283,7 +283,7 @@ local function _filter_blocks_in_dir (blocks, target)
     pandoc.system.with_working_directory(
             pandoc.path.directory(target),    -- may still contain '../'
             function ()
-                -- when processing the start file: remember the level of it's subdir(s) relative to project root
+                -- when processing the start file: remember the level of its subdir(s) relative to project root
                 -- "a/b/readme.md" => remember "a/b" to avoid trying to include 'readme.md' files above this level (except when directly linked to)
                 if LEVEL_STARTFILE == nil then
                     LEVEL_STARTFILE = _prepend_include_path(".")

--- a/filters/hugo_makedeps.lua
+++ b/filters/hugo_makedeps.lua
@@ -352,8 +352,8 @@ function Pandoc (doc)
     local input_files = PANDOC_STATE.input_files
     local file = #input_files >= 1 and input_files[#input_files] or "."
 
-    -- landing page: process all images and links
-    _handle_file(file)
+    -- enqueue landing page for processing
+    _enqueue(_prepend_include_path(file))
 
     -- process files recursively: breadth-first search
     local target = _dequeue()

--- a/filters/test/expected_makedeps1.native
+++ b/filters/test/expected_makedeps1.native
@@ -6,6 +6,10 @@
     , RawInline
         (Format "markdown") "WEB_IMAGE_TARGETS += file-b/a.png\n\n"
     , RawInline
+        (Format "markdown") "subdir/c.png: subdir/img/c.png\n"
+    , RawInline
+        (Format "markdown") "WEB_IMAGE_TARGETS += subdir/c.png\n\n"
+    , RawInline
         (Format "markdown")
         "subdir/file-e/c.png: subdir/img/c.png\n"
     , RawInline
@@ -13,14 +17,16 @@
         "WEB_IMAGE_TARGETS += subdir/file-e/c.png\n\n"
     , RawInline
         (Format "markdown")
+        "subdir/leaf/b.png: subdir/leaf/img/b.png\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_IMAGE_TARGETS += subdir/leaf/b.png\n\n"
+    , RawInline
+        (Format "markdown")
         "subdir/leaf/foo/b.png: subdir/leaf/img/b.png\n"
     , RawInline
         (Format "markdown")
         "WEB_IMAGE_TARGETS += subdir/leaf/foo/b.png\n\n"
-    , RawInline
-        (Format "markdown") "subdir/c.png: subdir/img/c.png\n"
-    , RawInline
-        (Format "markdown") "WEB_IMAGE_TARGETS += subdir/c.png\n\n"
     , RawInline
         (Format "markdown")
         "orga/syllabus/modulbeschreibung.png: orga/img/modulbeschreibung.png\n"
@@ -39,12 +45,6 @@
     , RawInline
         (Format "markdown")
         "WEB_IMAGE_TARGETS += subdir/leaf/bar/d.png\n\n"
-    , RawInline
-        (Format "markdown")
-        "subdir/leaf/b.png: subdir/leaf/img/b.png\n"
-    , RawInline
-        (Format "markdown")
-        "WEB_IMAGE_TARGETS += subdir/leaf/b.png\n\n"
     ]
 , Plain
     [ RawInline (Format "markdown") "_index.md: readme.md\n"
@@ -69,10 +69,19 @@
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += file-b/_index.md\n\n"
     , RawInline
+        (Format "markdown") "subdir/_index.md: subdir/readme.md\n"
+    , RawInline
+        (Format "markdown") "subdir/_index.md: subdir/c.png\n"
+    , RawInline
+        (Format "markdown") "subdir/_index.md: WEIGHT=4\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += subdir/_index.md\n\n"
+    , RawInline
         (Format "markdown")
         "subdir/file-d/_index.md: subdir/file-d.md\n"
     , RawInline
-        (Format "markdown") "subdir/file-d/_index.md: WEIGHT=4\n"
+        (Format "markdown") "subdir/file-d/_index.md: WEIGHT=5\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += subdir/file-d/_index.md\n\n"
@@ -83,10 +92,21 @@
         (Format "markdown")
         "subdir/file-e/_index.md: subdir/file-e/c.png\n"
     , RawInline
-        (Format "markdown") "subdir/file-e/_index.md: WEIGHT=5\n"
+        (Format "markdown") "subdir/file-e/_index.md: WEIGHT=6\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += subdir/file-e/_index.md\n\n"
+    , RawInline
+        (Format "markdown")
+        "subdir/leaf/_index.md: subdir/leaf/readme.md\n"
+    , RawInline
+        (Format "markdown")
+        "subdir/leaf/_index.md: subdir/leaf/b.png\n"
+    , RawInline
+        (Format "markdown") "subdir/leaf/_index.md: WEIGHT=7\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += subdir/leaf/_index.md\n\n"
     , RawInline
         (Format "markdown")
         "subdir/leaf/foo/_index.md: subdir/leaf/foo.md\n"
@@ -94,19 +114,16 @@
         (Format "markdown")
         "subdir/leaf/foo/_index.md: subdir/leaf/foo/b.png\n"
     , RawInline
-        (Format "markdown") "subdir/leaf/foo/_index.md: WEIGHT=6\n"
+        (Format "markdown") "subdir/leaf/foo/_index.md: WEIGHT=8\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += subdir/leaf/foo/_index.md\n\n"
     , RawInline
-        (Format "markdown") "subdir/_index.md: subdir/readme.md\n"
-    , RawInline
-        (Format "markdown") "subdir/_index.md: subdir/c.png\n"
-    , RawInline
-        (Format "markdown") "subdir/_index.md: WEIGHT=7\n"
+        (Format "markdown") "orga/_index.md: orga/readme.md\n"
+    , RawInline (Format "markdown") "orga/_index.md: WEIGHT=9\n"
     , RawInline
         (Format "markdown")
-        "WEB_MARKDOWN_TARGETS += subdir/_index.md\n\n"
+        "WEB_MARKDOWN_TARGETS += orga/_index.md\n\n"
     , RawInline
         (Format "markdown")
         "orga/syllabus/_index.md: orga/syllabus.md\n"
@@ -114,7 +131,7 @@
         (Format "markdown")
         "orga/syllabus/_index.md: orga/syllabus/modulbeschreibung.png\n"
     , RawInline
-        (Format "markdown") "orga/syllabus/_index.md: WEIGHT=8\n"
+        (Format "markdown") "orga/syllabus/_index.md: WEIGHT=10\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += orga/syllabus/_index.md\n\n"
@@ -122,14 +139,14 @@
         (Format "markdown")
         "orga/resources/_index.md: orga/resources.md\n"
     , RawInline
-        (Format "markdown") "orga/resources/_index.md: WEIGHT=9\n"
+        (Format "markdown") "orga/resources/_index.md: WEIGHT=11\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += orga/resources/_index.md\n\n"
     , RawInline
         (Format "markdown") "orga/exams/_index.md: orga/exams.md\n"
     , RawInline
-        (Format "markdown") "orga/exams/_index.md: WEIGHT=10\n"
+        (Format "markdown") "orga/exams/_index.md: WEIGHT=12\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += orga/exams/_index.md\n\n"
@@ -137,7 +154,7 @@
         (Format "markdown")
         "orga/grading/_index.md: orga/grading.md\n"
     , RawInline
-        (Format "markdown") "orga/grading/_index.md: WEIGHT=11\n"
+        (Format "markdown") "orga/grading/_index.md: WEIGHT=13\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += orga/grading/_index.md\n\n"
@@ -148,27 +165,9 @@
         (Format "markdown")
         "subdir/leaf/bar/_index.md: subdir/leaf/bar/b.png subdir/leaf/bar/d.png\n"
     , RawInline
-        (Format "markdown") "subdir/leaf/bar/_index.md: WEIGHT=12\n"
+        (Format "markdown") "subdir/leaf/bar/_index.md: WEIGHT=14\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += subdir/leaf/bar/_index.md\n\n"
-    , RawInline
-        (Format "markdown")
-        "subdir/leaf/_index.md: subdir/leaf/readme.md\n"
-    , RawInline
-        (Format "markdown")
-        "subdir/leaf/_index.md: subdir/leaf/b.png\n"
-    , RawInline
-        (Format "markdown") "subdir/leaf/_index.md: WEIGHT=13\n"
-    , RawInline
-        (Format "markdown")
-        "WEB_MARKDOWN_TARGETS += subdir/leaf/_index.md\n\n"
-    , RawInline
-        (Format "markdown") "orga/_index.md: orga/readme.md\n"
-    , RawInline
-        (Format "markdown") "orga/_index.md: WEIGHT=14\n"
-    , RawInline
-        (Format "markdown")
-        "WEB_MARKDOWN_TARGETS += orga/_index.md\n\n"
     ]
 ]

--- a/filters/test/expected_makedeps3.native
+++ b/filters/test/expected_makedeps3.native
@@ -6,6 +6,10 @@
     , RawInline
         (Format "markdown") "WEB_IMAGE_TARGETS += file-b/a.png\n\n"
     , RawInline
+        (Format "markdown") "subdir/c.png: subdir/img/c.png\n"
+    , RawInline
+        (Format "markdown") "WEB_IMAGE_TARGETS += subdir/c.png\n\n"
+    , RawInline
         (Format "markdown")
         "subdir/file-e/c.png: subdir/img/c.png\n"
     , RawInline
@@ -13,14 +17,16 @@
         "WEB_IMAGE_TARGETS += subdir/file-e/c.png\n\n"
     , RawInline
         (Format "markdown")
+        "subdir/leaf/b.png: subdir/leaf/img/b.png\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_IMAGE_TARGETS += subdir/leaf/b.png\n\n"
+    , RawInline
+        (Format "markdown")
         "subdir/leaf/foo/b.png: subdir/leaf/img/b.png\n"
     , RawInline
         (Format "markdown")
         "WEB_IMAGE_TARGETS += subdir/leaf/foo/b.png\n\n"
-    , RawInline
-        (Format "markdown") "subdir/c.png: subdir/img/c.png\n"
-    , RawInline
-        (Format "markdown") "WEB_IMAGE_TARGETS += subdir/c.png\n\n"
     , RawInline
         (Format "markdown")
         "orga/syllabus/modulbeschreibung.png: orga/img/modulbeschreibung.png\n"
@@ -39,12 +45,6 @@
     , RawInline
         (Format "markdown")
         "WEB_IMAGE_TARGETS += subdir/leaf/bar/d.png\n\n"
-    , RawInline
-        (Format "markdown")
-        "subdir/leaf/b.png: subdir/leaf/img/b.png\n"
-    , RawInline
-        (Format "markdown")
-        "WEB_IMAGE_TARGETS += subdir/leaf/b.png\n\n"
     ]
 , Plain
     [ RawInline (Format "markdown") "_index.md: readme.md\n"
@@ -69,10 +69,19 @@
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += file-b/_index.md\n\n"
     , RawInline
+        (Format "markdown") "subdir/_index.md: subdir/readme.md\n"
+    , RawInline
+        (Format "markdown") "subdir/_index.md: subdir/c.png\n"
+    , RawInline
+        (Format "markdown") "subdir/_index.md: WEIGHT=4\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += subdir/_index.md\n\n"
+    , RawInline
         (Format "markdown")
         "subdir/file-d/_index.md: subdir/file-d.md\n"
     , RawInline
-        (Format "markdown") "subdir/file-d/_index.md: WEIGHT=4\n"
+        (Format "markdown") "subdir/file-d/_index.md: WEIGHT=5\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += subdir/file-d/_index.md\n\n"
@@ -83,10 +92,21 @@
         (Format "markdown")
         "subdir/file-e/_index.md: subdir/file-e/c.png\n"
     , RawInline
-        (Format "markdown") "subdir/file-e/_index.md: WEIGHT=5\n"
+        (Format "markdown") "subdir/file-e/_index.md: WEIGHT=6\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += subdir/file-e/_index.md\n\n"
+    , RawInline
+        (Format "markdown")
+        "subdir/leaf/_index.md: subdir/leaf/readme.md\n"
+    , RawInline
+        (Format "markdown")
+        "subdir/leaf/_index.md: subdir/leaf/b.png\n"
+    , RawInline
+        (Format "markdown") "subdir/leaf/_index.md: WEIGHT=7\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += subdir/leaf/_index.md\n\n"
     , RawInline
         (Format "markdown")
         "subdir/leaf/foo/_index.md: subdir/leaf/foo.md\n"
@@ -94,19 +114,16 @@
         (Format "markdown")
         "subdir/leaf/foo/_index.md: subdir/leaf/foo/b.png\n"
     , RawInline
-        (Format "markdown") "subdir/leaf/foo/_index.md: WEIGHT=6\n"
+        (Format "markdown") "subdir/leaf/foo/_index.md: WEIGHT=8\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += subdir/leaf/foo/_index.md\n\n"
     , RawInline
-        (Format "markdown") "subdir/_index.md: subdir/readme.md\n"
-    , RawInline
-        (Format "markdown") "subdir/_index.md: subdir/c.png\n"
-    , RawInline
-        (Format "markdown") "subdir/_index.md: WEIGHT=7\n"
+        (Format "markdown") "orga/_index.md: orga/readme.md\n"
+    , RawInline (Format "markdown") "orga/_index.md: WEIGHT=9\n"
     , RawInline
         (Format "markdown")
-        "WEB_MARKDOWN_TARGETS += subdir/_index.md\n\n"
+        "WEB_MARKDOWN_TARGETS += orga/_index.md\n\n"
     , RawInline
         (Format "markdown")
         "orga/syllabus/_index.md: orga/syllabus.md\n"
@@ -114,7 +131,7 @@
         (Format "markdown")
         "orga/syllabus/_index.md: orga/syllabus/modulbeschreibung.png\n"
     , RawInline
-        (Format "markdown") "orga/syllabus/_index.md: WEIGHT=8\n"
+        (Format "markdown") "orga/syllabus/_index.md: WEIGHT=10\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += orga/syllabus/_index.md\n\n"
@@ -122,14 +139,14 @@
         (Format "markdown")
         "orga/resources/_index.md: orga/resources.md\n"
     , RawInline
-        (Format "markdown") "orga/resources/_index.md: WEIGHT=9\n"
+        (Format "markdown") "orga/resources/_index.md: WEIGHT=11\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += orga/resources/_index.md\n\n"
     , RawInline
         (Format "markdown") "orga/exams/_index.md: orga/exams.md\n"
     , RawInline
-        (Format "markdown") "orga/exams/_index.md: WEIGHT=10\n"
+        (Format "markdown") "orga/exams/_index.md: WEIGHT=12\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += orga/exams/_index.md\n\n"
@@ -137,7 +154,7 @@
         (Format "markdown")
         "orga/grading/_index.md: orga/grading.md\n"
     , RawInline
-        (Format "markdown") "orga/grading/_index.md: WEIGHT=11\n"
+        (Format "markdown") "orga/grading/_index.md: WEIGHT=13\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += orga/grading/_index.md\n\n"
@@ -148,27 +165,9 @@
         (Format "markdown")
         "subdir/leaf/bar/_index.md: subdir/leaf/bar/b.png subdir/leaf/bar/d.png\n"
     , RawInline
-        (Format "markdown") "subdir/leaf/bar/_index.md: WEIGHT=12\n"
+        (Format "markdown") "subdir/leaf/bar/_index.md: WEIGHT=14\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += subdir/leaf/bar/_index.md\n\n"
-    , RawInline
-        (Format "markdown")
-        "subdir/leaf/_index.md: subdir/leaf/readme.md\n"
-    , RawInline
-        (Format "markdown")
-        "subdir/leaf/_index.md: subdir/leaf/b.png\n"
-    , RawInline
-        (Format "markdown") "subdir/leaf/_index.md: WEIGHT=13\n"
-    , RawInline
-        (Format "markdown")
-        "WEB_MARKDOWN_TARGETS += subdir/leaf/_index.md\n\n"
-    , RawInline
-        (Format "markdown") "orga/_index.md: orga/readme.md\n"
-    , RawInline
-        (Format "markdown") "orga/_index.md: WEIGHT=14\n"
-    , RawInline
-        (Format "markdown")
-        "WEB_MARKDOWN_TARGETS += orga/_index.md\n\n"
     ]
 ]

--- a/filters/test/expected_makedeps4.native
+++ b/filters/test/expected_makedeps4.native
@@ -9,22 +9,28 @@
         "WEB_IMAGE_TARGETS += foobar/file-b/a.png\n\n"
     , RawInline
         (Format "markdown")
+        "foobar/subdir/c.png: subdir/img/c.png\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_IMAGE_TARGETS += foobar/subdir/c.png\n\n"
+    , RawInline
+        (Format "markdown")
         "foobar/subdir/file-e/c.png: subdir/img/c.png\n"
     , RawInline
         (Format "markdown")
         "WEB_IMAGE_TARGETS += foobar/subdir/file-e/c.png\n\n"
     , RawInline
         (Format "markdown")
+        "foobar/subdir/leaf/b.png: subdir/leaf/img/b.png\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_IMAGE_TARGETS += foobar/subdir/leaf/b.png\n\n"
+    , RawInline
+        (Format "markdown")
         "foobar/subdir/leaf/foo/b.png: subdir/leaf/img/b.png\n"
     , RawInline
         (Format "markdown")
         "WEB_IMAGE_TARGETS += foobar/subdir/leaf/foo/b.png\n\n"
-    , RawInline
-        (Format "markdown")
-        "foobar/subdir/c.png: subdir/img/c.png\n"
-    , RawInline
-        (Format "markdown")
-        "WEB_IMAGE_TARGETS += foobar/subdir/c.png\n\n"
     , RawInline
         (Format "markdown")
         "foobar/orga/syllabus/modulbeschreibung.png: orga/img/modulbeschreibung.png\n"
@@ -43,12 +49,6 @@
     , RawInline
         (Format "markdown")
         "WEB_IMAGE_TARGETS += foobar/subdir/leaf/bar/d.png\n\n"
-    , RawInline
-        (Format "markdown")
-        "foobar/subdir/leaf/b.png: subdir/leaf/img/b.png\n"
-    , RawInline
-        (Format "markdown")
-        "WEB_IMAGE_TARGETS += foobar/subdir/leaf/b.png\n\n"
     ]
 , Plain
     [ RawInline
@@ -79,10 +79,21 @@
         "WEB_MARKDOWN_TARGETS += foobar/file-b/_index.md\n\n"
     , RawInline
         (Format "markdown")
+        "foobar/subdir/_index.md: subdir/readme.md\n"
+    , RawInline
+        (Format "markdown")
+        "foobar/subdir/_index.md: foobar/subdir/c.png\n"
+    , RawInline
+        (Format "markdown") "foobar/subdir/_index.md: WEIGHT=4\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += foobar/subdir/_index.md\n\n"
+    , RawInline
+        (Format "markdown")
         "foobar/subdir/file-d/_index.md: subdir/file-d.md\n"
     , RawInline
         (Format "markdown")
-        "foobar/subdir/file-d/_index.md: WEIGHT=4\n"
+        "foobar/subdir/file-d/_index.md: WEIGHT=5\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += foobar/subdir/file-d/_index.md\n\n"
@@ -94,10 +105,22 @@
         "foobar/subdir/file-e/_index.md: foobar/subdir/file-e/c.png\n"
     , RawInline
         (Format "markdown")
-        "foobar/subdir/file-e/_index.md: WEIGHT=5\n"
+        "foobar/subdir/file-e/_index.md: WEIGHT=6\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += foobar/subdir/file-e/_index.md\n\n"
+    , RawInline
+        (Format "markdown")
+        "foobar/subdir/leaf/_index.md: subdir/leaf/readme.md\n"
+    , RawInline
+        (Format "markdown")
+        "foobar/subdir/leaf/_index.md: foobar/subdir/leaf/b.png\n"
+    , RawInline
+        (Format "markdown")
+        "foobar/subdir/leaf/_index.md: WEIGHT=7\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += foobar/subdir/leaf/_index.md\n\n"
     , RawInline
         (Format "markdown")
         "foobar/subdir/leaf/foo/_index.md: subdir/leaf/foo.md\n"
@@ -106,21 +129,18 @@
         "foobar/subdir/leaf/foo/_index.md: foobar/subdir/leaf/foo/b.png\n"
     , RawInline
         (Format "markdown")
-        "foobar/subdir/leaf/foo/_index.md: WEIGHT=6\n"
+        "foobar/subdir/leaf/foo/_index.md: WEIGHT=8\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += foobar/subdir/leaf/foo/_index.md\n\n"
     , RawInline
         (Format "markdown")
-        "foobar/subdir/_index.md: subdir/readme.md\n"
+        "foobar/orga/_index.md: orga/readme.md\n"
+    , RawInline
+        (Format "markdown") "foobar/orga/_index.md: WEIGHT=9\n"
     , RawInline
         (Format "markdown")
-        "foobar/subdir/_index.md: foobar/subdir/c.png\n"
-    , RawInline
-        (Format "markdown") "foobar/subdir/_index.md: WEIGHT=7\n"
-    , RawInline
-        (Format "markdown")
-        "WEB_MARKDOWN_TARGETS += foobar/subdir/_index.md\n\n"
+        "WEB_MARKDOWN_TARGETS += foobar/orga/_index.md\n\n"
     , RawInline
         (Format "markdown")
         "foobar/orga/syllabus/_index.md: orga/syllabus.md\n"
@@ -129,7 +149,7 @@
         "foobar/orga/syllabus/_index.md: foobar/orga/syllabus/modulbeschreibung.png\n"
     , RawInline
         (Format "markdown")
-        "foobar/orga/syllabus/_index.md: WEIGHT=8\n"
+        "foobar/orga/syllabus/_index.md: WEIGHT=10\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += foobar/orga/syllabus/_index.md\n\n"
@@ -138,7 +158,7 @@
         "foobar/orga/resources/_index.md: orga/resources.md\n"
     , RawInline
         (Format "markdown")
-        "foobar/orga/resources/_index.md: WEIGHT=9\n"
+        "foobar/orga/resources/_index.md: WEIGHT=11\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += foobar/orga/resources/_index.md\n\n"
@@ -147,7 +167,7 @@
         "foobar/orga/exams/_index.md: orga/exams.md\n"
     , RawInline
         (Format "markdown")
-        "foobar/orga/exams/_index.md: WEIGHT=10\n"
+        "foobar/orga/exams/_index.md: WEIGHT=12\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += foobar/orga/exams/_index.md\n\n"
@@ -156,7 +176,7 @@
         "foobar/orga/grading/_index.md: orga/grading.md\n"
     , RawInline
         (Format "markdown")
-        "foobar/orga/grading/_index.md: WEIGHT=11\n"
+        "foobar/orga/grading/_index.md: WEIGHT=13\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += foobar/orga/grading/_index.md\n\n"
@@ -168,29 +188,9 @@
         "foobar/subdir/leaf/bar/_index.md: foobar/subdir/leaf/bar/b.png foobar/subdir/leaf/bar/d.png\n"
     , RawInline
         (Format "markdown")
-        "foobar/subdir/leaf/bar/_index.md: WEIGHT=12\n"
+        "foobar/subdir/leaf/bar/_index.md: WEIGHT=14\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += foobar/subdir/leaf/bar/_index.md\n\n"
-    , RawInline
-        (Format "markdown")
-        "foobar/subdir/leaf/_index.md: subdir/leaf/readme.md\n"
-    , RawInline
-        (Format "markdown")
-        "foobar/subdir/leaf/_index.md: foobar/subdir/leaf/b.png\n"
-    , RawInline
-        (Format "markdown")
-        "foobar/subdir/leaf/_index.md: WEIGHT=13\n"
-    , RawInline
-        (Format "markdown")
-        "WEB_MARKDOWN_TARGETS += foobar/subdir/leaf/_index.md\n\n"
-    , RawInline
-        (Format "markdown")
-        "foobar/orga/_index.md: orga/readme.md\n"
-    , RawInline
-        (Format "markdown") "foobar/orga/_index.md: WEIGHT=14\n"
-    , RawInline
-        (Format "markdown")
-        "WEB_MARKDOWN_TARGETS += foobar/orga/_index.md\n\n"
     ]
 ]

--- a/filters/test/expected_makedeps5.native
+++ b/filters/test/expected_makedeps5.native
@@ -5,16 +5,16 @@
         (Format "markdown") "WEB_IMAGE_TARGETS += subdir/c.png\n\n"
     , RawInline
         (Format "markdown")
-        "subdir/leaf/foo/b.png: subdir/leaf/img/b.png\n"
-    , RawInline
-        (Format "markdown")
-        "WEB_IMAGE_TARGETS += subdir/leaf/foo/b.png\n\n"
-    , RawInline
-        (Format "markdown")
         "subdir/leaf/b.png: subdir/leaf/img/b.png\n"
     , RawInline
         (Format "markdown")
         "WEB_IMAGE_TARGETS += subdir/leaf/b.png\n\n"
+    , RawInline
+        (Format "markdown")
+        "subdir/leaf/foo/b.png: subdir/leaf/img/b.png\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_IMAGE_TARGETS += subdir/leaf/foo/b.png\n\n"
     , RawInline
         (Format "markdown")
         "subdir/leaf/bar/b.png: subdir/leaf/img/b.png\n"
@@ -40,26 +40,26 @@
         "WEB_MARKDOWN_TARGETS += subdir/_index.md\n\n"
     , RawInline
         (Format "markdown")
-        "subdir/leaf/foo/_index.md: subdir/leaf/foo.md\n"
-    , RawInline
-        (Format "markdown")
-        "subdir/leaf/foo/_index.md: subdir/leaf/foo/b.png\n"
-    , RawInline
-        (Format "markdown") "subdir/leaf/foo/_index.md: WEIGHT=2\n"
-    , RawInline
-        (Format "markdown")
-        "WEB_MARKDOWN_TARGETS += subdir/leaf/foo/_index.md\n\n"
-    , RawInline
-        (Format "markdown")
         "subdir/leaf/_index.md: subdir/leaf/readme.md\n"
     , RawInline
         (Format "markdown")
         "subdir/leaf/_index.md: subdir/leaf/b.png\n"
     , RawInline
-        (Format "markdown") "subdir/leaf/_index.md: WEIGHT=3\n"
+        (Format "markdown") "subdir/leaf/_index.md: WEIGHT=2\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += subdir/leaf/_index.md\n\n"
+    , RawInline
+        (Format "markdown")
+        "subdir/leaf/foo/_index.md: subdir/leaf/foo.md\n"
+    , RawInline
+        (Format "markdown")
+        "subdir/leaf/foo/_index.md: subdir/leaf/foo/b.png\n"
+    , RawInline
+        (Format "markdown") "subdir/leaf/foo/_index.md: WEIGHT=3\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += subdir/leaf/foo/_index.md\n\n"
     , RawInline
         (Format "markdown")
         "subdir/leaf/bar/_index.md: subdir/leaf/bar.md\n"

--- a/filters/test/expected_makedeps7.native
+++ b/filters/test/expected_makedeps7.native
@@ -10,6 +10,10 @@
     , RawInline
         (Format "markdown") "WEB_IMAGE_TARGETS += file-e/c.png\n\n"
     , RawInline
+        (Format "markdown") "leaf/b.png: subdir/leaf/img/b.png\n"
+    , RawInline
+        (Format "markdown") "WEB_IMAGE_TARGETS += leaf/b.png\n\n"
+    , RawInline
         (Format "markdown")
         "leaf/foo/b.png: subdir/leaf/img/b.png\n"
     , RawInline
@@ -33,10 +37,6 @@
     , RawInline
         (Format "markdown")
         "WEB_IMAGE_TARGETS += leaf/bar/d.png\n\n"
-    , RawInline
-        (Format "markdown") "leaf/b.png: subdir/leaf/img/b.png\n"
-    , RawInline
-        (Format "markdown") "WEB_IMAGE_TARGETS += leaf/b.png\n\n"
     ]
 , Plain
     [ RawInline (Format "markdown") "_index.md: readme.md\n"
@@ -78,14 +78,29 @@
         "WEB_MARKDOWN_TARGETS += file-e/_index.md\n\n"
     , RawInline
         (Format "markdown")
+        "leaf/_index.md: subdir/leaf/readme.md\n"
+    , RawInline
+        (Format "markdown") "leaf/_index.md: leaf/b.png\n"
+    , RawInline (Format "markdown") "leaf/_index.md: WEIGHT=6\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += leaf/_index.md\n\n"
+    , RawInline
+        (Format "markdown")
         "leaf/foo/_index.md: subdir/leaf/foo.md\n"
     , RawInline
         (Format "markdown") "leaf/foo/_index.md: leaf/foo/b.png\n"
     , RawInline
-        (Format "markdown") "leaf/foo/_index.md: WEIGHT=6\n"
+        (Format "markdown") "leaf/foo/_index.md: WEIGHT=7\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += leaf/foo/_index.md\n\n"
+    , RawInline
+        (Format "markdown") "orga/_index.md: orga/readme.md\n"
+    , RawInline (Format "markdown") "orga/_index.md: WEIGHT=8\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += orga/_index.md\n\n"
     , RawInline
         (Format "markdown")
         "orga/syllabus/_index.md: orga/syllabus.md\n"
@@ -93,7 +108,7 @@
         (Format "markdown")
         "orga/syllabus/_index.md: orga/syllabus/modulbeschreibung.png\n"
     , RawInline
-        (Format "markdown") "orga/syllabus/_index.md: WEIGHT=7\n"
+        (Format "markdown") "orga/syllabus/_index.md: WEIGHT=9\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += orga/syllabus/_index.md\n\n"
@@ -101,14 +116,14 @@
         (Format "markdown")
         "orga/resources/_index.md: orga/resources.md\n"
     , RawInline
-        (Format "markdown") "orga/resources/_index.md: WEIGHT=8\n"
+        (Format "markdown") "orga/resources/_index.md: WEIGHT=10\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += orga/resources/_index.md\n\n"
     , RawInline
         (Format "markdown") "orga/exams/_index.md: orga/exams.md\n"
     , RawInline
-        (Format "markdown") "orga/exams/_index.md: WEIGHT=9\n"
+        (Format "markdown") "orga/exams/_index.md: WEIGHT=11\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += orga/exams/_index.md\n\n"
@@ -116,7 +131,7 @@
         (Format "markdown")
         "orga/grading/_index.md: orga/grading.md\n"
     , RawInline
-        (Format "markdown") "orga/grading/_index.md: WEIGHT=10\n"
+        (Format "markdown") "orga/grading/_index.md: WEIGHT=12\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += orga/grading/_index.md\n\n"
@@ -127,26 +142,9 @@
         (Format "markdown")
         "leaf/bar/_index.md: leaf/bar/b.png leaf/bar/d.png\n"
     , RawInline
-        (Format "markdown") "leaf/bar/_index.md: WEIGHT=11\n"
+        (Format "markdown") "leaf/bar/_index.md: WEIGHT=13\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += leaf/bar/_index.md\n\n"
-    , RawInline
-        (Format "markdown")
-        "leaf/_index.md: subdir/leaf/readme.md\n"
-    , RawInline
-        (Format "markdown") "leaf/_index.md: leaf/b.png\n"
-    , RawInline
-        (Format "markdown") "leaf/_index.md: WEIGHT=12\n"
-    , RawInline
-        (Format "markdown")
-        "WEB_MARKDOWN_TARGETS += leaf/_index.md\n\n"
-    , RawInline
-        (Format "markdown") "orga/_index.md: orga/readme.md\n"
-    , RawInline
-        (Format "markdown") "orga/_index.md: WEIGHT=13\n"
-    , RawInline
-        (Format "markdown")
-        "WEB_MARKDOWN_TARGETS += orga/_index.md\n\n"
     ]
 ]

--- a/filters/test/expected_makedeps8.native
+++ b/filters/test/expected_makedeps8.native
@@ -6,6 +6,10 @@
     , RawInline
         (Format "markdown") "WEB_IMAGE_TARGETS += file-b/a.png\n\n"
     , RawInline
+        (Format "markdown") "subdir/c.png: subdir/img/c.png\n"
+    , RawInline
+        (Format "markdown") "WEB_IMAGE_TARGETS += subdir/c.png\n\n"
+    , RawInline
         (Format "markdown")
         "subdir/file-e/c.png: subdir/img/c.png\n"
     , RawInline
@@ -17,10 +21,6 @@
     , RawInline
         (Format "markdown")
         "WEB_IMAGE_TARGETS += subdir/foo/b.png\n\n"
-    , RawInline
-        (Format "markdown") "subdir/c.png: subdir/img/c.png\n"
-    , RawInline
-        (Format "markdown") "WEB_IMAGE_TARGETS += subdir/c.png\n\n"
     , RawInline
         (Format "markdown")
         "orga/syllabus/modulbeschreibung.png: orga/img/modulbeschreibung.png\n"
@@ -63,10 +63,19 @@
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += file-b/_index.md\n\n"
     , RawInline
+        (Format "markdown") "subdir/_index.md: subdir/readme.md\n"
+    , RawInline
+        (Format "markdown") "subdir/_index.md: subdir/c.png\n"
+    , RawInline
+        (Format "markdown") "subdir/_index.md: WEIGHT=4\n"
+    , RawInline
+        (Format "markdown")
+        "WEB_MARKDOWN_TARGETS += subdir/_index.md\n\n"
+    , RawInline
         (Format "markdown")
         "subdir/file-d/_index.md: subdir/file-d.md\n"
     , RawInline
-        (Format "markdown") "subdir/file-d/_index.md: WEIGHT=4\n"
+        (Format "markdown") "subdir/file-d/_index.md: WEIGHT=5\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += subdir/file-d/_index.md\n\n"
@@ -77,7 +86,7 @@
         (Format "markdown")
         "subdir/file-e/_index.md: subdir/file-e/c.png\n"
     , RawInline
-        (Format "markdown") "subdir/file-e/_index.md: WEIGHT=5\n"
+        (Format "markdown") "subdir/file-e/_index.md: WEIGHT=6\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += subdir/file-e/_index.md\n\n"
@@ -88,19 +97,16 @@
         (Format "markdown")
         "subdir/foo/_index.md: subdir/foo/b.png\n"
     , RawInline
-        (Format "markdown") "subdir/foo/_index.md: WEIGHT=6\n"
+        (Format "markdown") "subdir/foo/_index.md: WEIGHT=7\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += subdir/foo/_index.md\n\n"
     , RawInline
-        (Format "markdown") "subdir/_index.md: subdir/readme.md\n"
-    , RawInline
-        (Format "markdown") "subdir/_index.md: subdir/c.png\n"
-    , RawInline
-        (Format "markdown") "subdir/_index.md: WEIGHT=7\n"
+        (Format "markdown") "orga/_index.md: orga/readme.md\n"
+    , RawInline (Format "markdown") "orga/_index.md: WEIGHT=8\n"
     , RawInline
         (Format "markdown")
-        "WEB_MARKDOWN_TARGETS += subdir/_index.md\n\n"
+        "WEB_MARKDOWN_TARGETS += orga/_index.md\n\n"
     , RawInline
         (Format "markdown")
         "orga/syllabus/_index.md: orga/syllabus.md\n"
@@ -108,7 +114,7 @@
         (Format "markdown")
         "orga/syllabus/_index.md: orga/syllabus/modulbeschreibung.png\n"
     , RawInline
-        (Format "markdown") "orga/syllabus/_index.md: WEIGHT=8\n"
+        (Format "markdown") "orga/syllabus/_index.md: WEIGHT=9\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += orga/syllabus/_index.md\n\n"
@@ -116,14 +122,14 @@
         (Format "markdown")
         "orga/resources/_index.md: orga/resources.md\n"
     , RawInline
-        (Format "markdown") "orga/resources/_index.md: WEIGHT=9\n"
+        (Format "markdown") "orga/resources/_index.md: WEIGHT=10\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += orga/resources/_index.md\n\n"
     , RawInline
         (Format "markdown") "orga/exams/_index.md: orga/exams.md\n"
     , RawInline
-        (Format "markdown") "orga/exams/_index.md: WEIGHT=10\n"
+        (Format "markdown") "orga/exams/_index.md: WEIGHT=11\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += orga/exams/_index.md\n\n"
@@ -131,7 +137,7 @@
         (Format "markdown")
         "orga/grading/_index.md: orga/grading.md\n"
     , RawInline
-        (Format "markdown") "orga/grading/_index.md: WEIGHT=11\n"
+        (Format "markdown") "orga/grading/_index.md: WEIGHT=12\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += orga/grading/_index.md\n\n"
@@ -142,16 +148,9 @@
         (Format "markdown")
         "subdir/bar/_index.md: subdir/bar/b.png subdir/bar/d.png\n"
     , RawInline
-        (Format "markdown") "subdir/bar/_index.md: WEIGHT=12\n"
+        (Format "markdown") "subdir/bar/_index.md: WEIGHT=13\n"
     , RawInline
         (Format "markdown")
         "WEB_MARKDOWN_TARGETS += subdir/bar/_index.md\n\n"
-    , RawInline
-        (Format "markdown") "orga/_index.md: orga/readme.md\n"
-    , RawInline
-        (Format "markdown") "orga/_index.md: WEIGHT=13\n"
-    , RawInline
-        (Format "markdown")
-        "WEB_MARKDOWN_TARGETS += orga/_index.md\n\n"
     ]
 ]


### PR DESCRIPTION
When analysing the current file, if a link is to be placed in the queue, first place all landing pages on the path to this file in the queue. 

This way, all intermediate landing pages are taken into account and cannot be missing later when the web page is created. Moreover, the order of the landing pages no longer depends directly on the links in the sub-files. 

If the start file was 'a/b/readme.md' and we want to enqueue the link 'a/b/c/d/foo.md', then we have to enqueue 'c/readme.md' and 'c/d/readme.me' first so that the order is correct. However, we must not take into account the partial path 'a/b/' because otherwise we would go back over the level of the start file. (This can happen, however, if links in the analysed files go back too far).


fixes #153