### PR TITLE
Filter: remove attributes from code blocks (hugo)

### DIFF
--- a/filters/hugo.lua
+++ b/filters/hugo.lua
@@ -62,6 +62,13 @@ function Image(el)
 end
 
 
+-- remove attributes from code block as hugo won't do syntax highlighting if attributes are present
+function CodeBlock(el)
+    el.attributes = {}
+    return el
+end
+
+
 -- Replace native Divs with "real" Divs or Shortcodes
 function Div(el)
     -- Replace "showme" Div with "expand" Shortcode

--- a/filters/hugo.lua
+++ b/filters/hugo.lua
@@ -62,7 +62,7 @@ function Image(el)
 end
 
 
--- remove attributes from code block as hugo won't do syntax highlighting if attributes are present
+-- remove attributes from code blocks as hugo won't do syntax highlighting if attributes are present
 function CodeBlock(el)
     el.attributes = {}
     return el

--- a/filters/hugo.lua
+++ b/filters/hugo.lua
@@ -69,6 +69,13 @@ function CodeBlock(el)
 end
 
 
+-- remove classes and other attributes from inline code as hugo won't do syntax highlighting if attributes are present
+function Code(el)
+    el.attr = {}
+    return el
+end
+
+
 -- Replace native Divs with "real" Divs or Shortcodes
 function Div(el)
     -- Replace "showme" Div with "expand" Shortcode

--- a/filters/test/Makefile
+++ b/filters/test/Makefile
@@ -15,7 +15,7 @@ LUA_MAKEDEPS     = ../hugo_makedeps.lua
 LUA_INCLUDEMD    = ../include_mdfiles.lua
 
 
-test: test_rewritelinks test_makedeps test_includemd test_tabs
+test: test_rewritelinks test_makedeps test_includemd test_tabs test_code
 
 test_rewritelinks: $(FILES_TRANSFORM)
 	@$(PANDOC) -L $(LUA_REWRITELINKS) -t native $^                                                     \
@@ -64,6 +64,10 @@ test_tabs: tabs_plain.md tabs_group.md tabs_title.md
 	    | $(DIFF) expected_tabs_group.native -
 	@$(PANDOC) -L ../hugo.lua -t native tabs_title.md                                                  \
 	    | $(DIFF) expected_tabs_title.native -
+
+test_code: codeblocks.md
+	@$(PANDOC) -L ../hugo.lua -t native codeblocks.md                                                  \
+	    | $(DIFF) expected_codeblocks.native -
 
 
 expected: expected_rewritelinks1.native expected_rewritelinks2.native expected_rewritelinks3.native expected_rewritelinks4.native expected_rewritelinks5.native
@@ -114,11 +118,16 @@ expected_tabs_group.native: tabs_group.md
 expected_tabs_title.native: tabs_title.md
 	$(PANDOC) -L ../hugo.lua -t native -o $@ $^
 
+expected: expected_codeblocks.native
+expected_codeblocks.native: codeblocks.md
+	$(PANDOC) -L ../hugo.lua -t native -o $@ $^
+
 
 clean:
 	rm -rf expected_rewritelinks1.native expected_rewritelinks2.native expected_rewritelinks3.native expected_rewritelinks4.native expected_rewritelinks5.native
 	rm -rf expected_makedeps1.native expected_makedeps2.native expected_makedeps3.native expected_makedeps4.native expected_makedeps5.native expected_makedeps6.native expected_makedeps7.native expected_makedeps8.native
 	rm -rf expected_inludemd1.native expected_inludemd2.native expected_inludemd3.native expected_inludemd4.native
 	rm -rf expected_tabs_plain.native expected_tabs_group.native expected_tabs_title.native
+	rm -rf expected_codeblocks.native
 
-.PHONY: test test_rewritelinks test_makedeps test_includemd test_tabs expected clean
+.PHONY: test test_rewritelinks test_makedeps test_includemd test_tabs test_code expected clean

--- a/filters/test/codeblocks.md
+++ b/filters/test/codeblocks.md
@@ -1,0 +1,19 @@
+wuppie fluppie
+
+```java
+class Foo {}
+```
+
+foo bar
+
+``` {.haskell size="tiny"}
+class Monad m where
+    (>>=) :: m a -> (a -> m b) -> m b
+    return :: a -> m a
+```
+
+lorem ipsum
+
+`void` is to be expected.
+
+`void`{.c}: same but highlighting.

--- a/filters/test/expected_codeblocks.native
+++ b/filters/test/expected_codeblocks.native
@@ -1,0 +1,29 @@
+[ Para [ Str "wuppie" , Space , Str "fluppie" ]
+, CodeBlock ( "" , [ "java" ] , [] ) "class Foo {}"
+, Para [ Str "foo" , Space , Str "bar" ]
+, CodeBlock
+    ( "" , [ "haskell" ] , [] )
+    "class Monad m where\n    (>>=) :: m a -> (a -> m b) -> m b\n    return :: a -> m a"
+, Para [ Str "lorem" , Space , Str "ipsum" ]
+, Para
+    [ Code ( "" , [] , [] ) "void"
+    , Space
+    , Str "is"
+    , Space
+    , Str "to"
+    , Space
+    , Str "be"
+    , Space
+    , Str "expected."
+    ]
+, Para
+    [ Code ( "" , [] , [] ) "void"
+    , Str ":"
+    , Space
+    , Str "same"
+    , Space
+    , Str "but"
+    , Space
+    , Str "highlighting."
+    ]
+]


### PR DESCRIPTION
In order to get proper syntax highlighting when using Hugo, 

- remove attributes from codeblocks, and 
- remove classes and attributes from inline code.

---

Examples:

    ``` {.haskell size="tiny"}
    class Monad m where
        (>>=) :: m a -> (a -> m b) -> m b
        return :: a -> m a
    ```

and 

    `void`{.c}

would not be recognised by Hugo. Thus this PR introduces some preprocessing and the `hugo.lua` filter will emit

    ``` haskell
    class Monad m where
        (>>=) :: m a -> (a -> m b) -> m b
        return :: a -> m a
    ```

and 

    `void`

---

fixes #83 