### PR TITLE
Filter: fix hugo filter for bsp span

### DIFF
--- a/filters/hugo.lua
+++ b/filters/hugo.lua
@@ -121,16 +121,28 @@ end
 
 -- Replace native Spans with "real" Spans or Shortcodes
 function Span(el)
-    -- Replace "bsp" span with "button" shortcode
+    -- Replace "bsp" span with "button" shortcode (if URL) or "badge" shortcode (if no URL)
     -- Use key/value pair "href=..." in span as href parameter in shortcode
     if el.classes[1] == "bsp" then
-        return {
-            pandoc.RawInline('markdown', '<div style="text-align: right;">'),
-            pandoc.RawInline('markdown', '{{% button style="btn-crossreference" href="' .. (el.attributes["href"] or "") .. '" %}}')
-        } .. el.content .. {
-            pandoc.RawInline('markdown', '{{% /button %}}'),
-            pandoc.RawInline('markdown', '</div>')
-        }
+        if el.attributes["href"] then
+            -- we've got an URL - make it a button (interactive)
+            return {
+                pandoc.RawInline('markdown', '<div style="text-align: right;">'),
+                pandoc.RawInline('markdown', '{{% button style="default" href="' .. el.attributes["href"] .. '" %}}')
+            } .. el.content .. {
+                pandoc.RawInline('markdown', '{{% /button %}}'),
+                pandoc.RawInline('markdown', '</div>')
+            }
+        else
+            -- no URL - make it a badge (non-interactive)
+            return {
+                pandoc.RawInline('markdown', '<div style="text-align: right;">'),
+                pandoc.RawInline('markdown', '{{% badge style="default" %}}')
+            } .. el.content .. {
+                pandoc.RawInline('markdown', '{{% /badge %}}'),
+                pandoc.RawInline('markdown', '</div>')
+            }
+        end
     end
 
     -- Transform all other native Spans to "real" Spans digestible to Hugo

--- a/filters/test/Makefile
+++ b/filters/test/Makefile
@@ -15,7 +15,7 @@ LUA_MAKEDEPS     = ../hugo_makedeps.lua
 LUA_INCLUDEMD    = ../include_mdfiles.lua
 
 
-test: test_rewritelinks test_makedeps test_includemd test_tabs test_code
+test: test_rewritelinks test_makedeps test_includemd test_tabs test_code test_bsp
 
 test_rewritelinks: $(FILES_TRANSFORM)
 	@$(PANDOC) -L $(LUA_REWRITELINKS) -t native $^                                                     \
@@ -68,6 +68,10 @@ test_tabs: tabs_plain.md tabs_group.md tabs_title.md
 test_code: codeblocks.md
 	@$(PANDOC) -L ../hugo.lua -t native codeblocks.md                                                  \
 	    | $(DIFF) expected_codeblocks.native -
+
+test_bsp: bsp_span.md
+	@$(PANDOC) -L ../hugo.lua -t native bsp_span.md                                                    \
+	    | $(DIFF) expected_bsp_span.native -
 
 
 expected: expected_rewritelinks1.native expected_rewritelinks2.native expected_rewritelinks3.native expected_rewritelinks4.native expected_rewritelinks5.native
@@ -122,6 +126,10 @@ expected: expected_codeblocks.native
 expected_codeblocks.native: codeblocks.md
 	$(PANDOC) -L ../hugo.lua -t native -o $@ $^
 
+expected: expected_bsp_span.native
+expected_bsp_span.native: bsp_span.md
+	$(PANDOC) -L ../hugo.lua -t native -o $@ $^
+
 
 clean:
 	rm -rf expected_rewritelinks1.native expected_rewritelinks2.native expected_rewritelinks3.native expected_rewritelinks4.native expected_rewritelinks5.native
@@ -129,5 +137,6 @@ clean:
 	rm -rf expected_inludemd1.native expected_inludemd2.native expected_inludemd3.native expected_inludemd4.native
 	rm -rf expected_tabs_plain.native expected_tabs_group.native expected_tabs_title.native
 	rm -rf expected_codeblocks.native
+	rm -rf expected_bsp_span.native
 
-.PHONY: test test_rewritelinks test_makedeps test_includemd test_tabs test_code expected clean
+.PHONY: test test_rewritelinks test_makedeps test_includemd test_tabs test_code test_bsp expected clean

--- a/filters/test/bsp_span.md
+++ b/filters/test/bsp_span.md
@@ -1,0 +1,13 @@
+## Vorlesung
+
+[Badge (non-interactive)]{.bsp}
+
+[Button (interactive)]{.bsp href="https://github.com/cagix/pandoc-lecture/pull/171"}
+
+Durchführung als **Flipped Classroom**: Sitzungen per Zoom (**Zugangsdaten siehe [ILIAS]**)
+
+[**Badge** (_non-interactive_)]{.bsp}
+
+[**Button** (_interactive_)]{.bsp href="https://github.com/cagix/pandoc-lecture/pull/171"}
+
+Durchführung als **Flipped Classroom**: Sitzungen per Zoom (**Zugangsdaten siehe [Moodle]**)

--- a/filters/test/expected_bsp_span.native
+++ b/filters/test/expected_bsp_span.native
@@ -1,0 +1,100 @@
+[ Header 2 ( "vorlesung" , [] , [] ) [ Str "Vorlesung" ]
+, Para
+    [ RawInline
+        (Format "markdown") "<div style=\"text-align: right;\">"
+    , RawInline
+        (Format "markdown") "{{% badge style=\"default\" %}}"
+    , Str "Badge"
+    , Space
+    , Str "(non-interactive)"
+    , RawInline (Format "markdown") "{{% /badge %}}"
+    , RawInline (Format "markdown") "</div>"
+    ]
+, Para
+    [ RawInline
+        (Format "markdown") "<div style=\"text-align: right;\">"
+    , RawInline
+        (Format "markdown")
+        "{{% button style=\"default\" href=\"https://github.com/cagix/pandoc-lecture/pull/171\" %}}"
+    , Str "Button"
+    , Space
+    , Str "(interactive)"
+    , RawInline (Format "markdown") "{{% /button %}}"
+    , RawInline (Format "markdown") "</div>"
+    ]
+, Para
+    [ Str "Durchf\252hrung"
+    , Space
+    , Str "als"
+    , Space
+    , Strong [ Str "Flipped" , Space , Str "Classroom" ]
+    , Str ":"
+    , Space
+    , Str "Sitzungen"
+    , Space
+    , Str "per"
+    , Space
+    , Str "Zoom"
+    , Space
+    , Str "("
+    , Strong
+        [ Str "Zugangsdaten"
+        , Space
+        , Str "siehe"
+        , Space
+        , Str "[ILIAS]"
+        ]
+    , Str ")"
+    ]
+, Para
+    [ RawInline
+        (Format "markdown") "<div style=\"text-align: right;\">"
+    , RawInline
+        (Format "markdown") "{{% badge style=\"default\" %}}"
+    , Strong [ Str "Badge" ]
+    , Space
+    , Str "("
+    , Emph [ Str "non-interactive" ]
+    , Str ")"
+    , RawInline (Format "markdown") "{{% /badge %}}"
+    , RawInline (Format "markdown") "</div>"
+    ]
+, Para
+    [ RawInline
+        (Format "markdown") "<div style=\"text-align: right;\">"
+    , RawInline
+        (Format "markdown")
+        "{{% button style=\"default\" href=\"https://github.com/cagix/pandoc-lecture/pull/171\" %}}"
+    , Strong [ Str "Button" ]
+    , Space
+    , Str "("
+    , Emph [ Str "interactive" ]
+    , Str ")"
+    , RawInline (Format "markdown") "{{% /button %}}"
+    , RawInline (Format "markdown") "</div>"
+    ]
+, Para
+    [ Str "Durchf\252hrung"
+    , Space
+    , Str "als"
+    , Space
+    , Strong [ Str "Flipped" , Space , Str "Classroom" ]
+    , Str ":"
+    , Space
+    , Str "Sitzungen"
+    , Space
+    , Str "per"
+    , Space
+    , Str "Zoom"
+    , Space
+    , Str "("
+    , Strong
+        [ Str "Zugangsdaten"
+        , Space
+        , Str "siehe"
+        , Space
+        , Str "[Moodle]"
+        ]
+    , Str ")"
+    ]
+]


### PR DESCRIPTION
if we use the bsp span with an url, we should emit an interactive button shortcode. otherwise let's use a non-interactive badge shortcode to avoid confusion ...