### PR TITLE
Filter: fix hugo filter for cbox div

### DIFF
--- a/filters/hugo.lua
+++ b/filters/hugo.lua
@@ -86,12 +86,12 @@ function Div(el)
             { pandoc.RawBlock("markdown", "{{% /expand %}}") }
     end
 
-    -- Replace "cbox" Div with centered "button" Shortcode
+    -- Replace "cbox" Div with centered "badge" Shortcode (non-interactive)
     if el.classes[1] == "cbox" then
         return
-            { pandoc.RawBlock("markdown", '<div style="text-align:center;">'), pandoc.RawBlock("markdown", '{{% button style="primary" %}}') } ..
+            { pandoc.RawBlock("markdown", '<div style="text-align:center;">'), pandoc.RawBlock("markdown", '{{% badge style="primary" %}}') } ..
             el.content ..
-            { pandoc.RawBlock("markdown", "{{% /button %}}"), pandoc.RawBlock("markdown", "</div>") }
+            { pandoc.RawBlock("markdown", "{{% /badge %}}"), pandoc.RawBlock("markdown", "</div>") }
     end
 
     -- Replace "tabs" Div with "tabs" Shortcode (may have a 'groupid')

--- a/filters/test/Makefile
+++ b/filters/test/Makefile
@@ -15,7 +15,7 @@ LUA_MAKEDEPS     = ../hugo_makedeps.lua
 LUA_INCLUDEMD    = ../include_mdfiles.lua
 
 
-test: test_rewritelinks test_makedeps test_includemd test_tabs test_code test_bsp
+test: test_rewritelinks test_makedeps test_includemd test_tabs test_code test_bsp test_cbox
 
 test_rewritelinks: $(FILES_TRANSFORM)
 	@$(PANDOC) -L $(LUA_REWRITELINKS) -t native $^                                                     \
@@ -72,6 +72,10 @@ test_code: codeblocks.md
 test_bsp: bsp_span.md
 	@$(PANDOC) -L ../hugo.lua -t native bsp_span.md                                                    \
 	    | $(DIFF) expected_bsp_span.native -
+
+test_cbox: cbox_div.md
+	@$(PANDOC) -L ../hugo.lua -t native cbox_div.md                                                    \
+	    | $(DIFF) expected_cbox_div.native -
 
 
 expected: expected_rewritelinks1.native expected_rewritelinks2.native expected_rewritelinks3.native expected_rewritelinks4.native expected_rewritelinks5.native
@@ -130,6 +134,10 @@ expected: expected_bsp_span.native
 expected_bsp_span.native: bsp_span.md
 	$(PANDOC) -L ../hugo.lua -t native -o $@ $^
 
+expected: expected_cbox_div.native
+expected_cbox_div.native: cbox_div.md
+	$(PANDOC) -L ../hugo.lua -t native -o $@ $^
+
 
 clean:
 	rm -rf expected_rewritelinks1.native expected_rewritelinks2.native expected_rewritelinks3.native expected_rewritelinks4.native expected_rewritelinks5.native
@@ -138,5 +146,6 @@ clean:
 	rm -rf expected_tabs_plain.native expected_tabs_group.native expected_tabs_title.native
 	rm -rf expected_codeblocks.native
 	rm -rf expected_bsp_span.native
+	rm -rf expected_cbox_div.native
 
-.PHONY: test test_rewritelinks test_makedeps test_includemd test_tabs test_code test_bsp expected clean
+.PHONY: test test_rewritelinks test_makedeps test_includemd test_tabs test_code test_bsp test_cbox expected clean

--- a/filters/test/cbox_div.md
+++ b/filters/test/cbox_div.md
@@ -1,0 +1,13 @@
+## Vorlesung
+
+::: cbox
+A simple text to be centred and accentuated
+:::
+
+Durchführung als **Flipped Classroom**: Sitzungen per Zoom (**Zugangsdaten siehe [ILIAS]**)
+
+::: cbox
+A **simple** text to be _centred_ and [accentuated]{.alert}
+:::
+
+Durchführung als **Flipped Classroom**: Sitzungen per Zoom (**Zugangsdaten siehe [Moodle]**)

--- a/filters/test/expected_cbox_div.native
+++ b/filters/test/expected_cbox_div.native
@@ -1,0 +1,98 @@
+[ Header 2 ( "vorlesung" , [] , [] ) [ Str "Vorlesung" ]
+, RawBlock
+    (Format "markdown") "<div style=\"text-align:center;\">"
+, RawBlock
+    (Format "markdown") "{{% badge style=\"primary\" %}}"
+, Para
+    [ Str "A"
+    , Space
+    , Str "simple"
+    , Space
+    , Str "text"
+    , Space
+    , Str "to"
+    , Space
+    , Str "be"
+    , Space
+    , Str "centred"
+    , Space
+    , Str "and"
+    , Space
+    , Str "accentuated"
+    ]
+, RawBlock (Format "markdown") "{{% /badge %}}"
+, RawBlock (Format "markdown") "</div>"
+, Para
+    [ Str "Durchf\252hrung"
+    , Space
+    , Str "als"
+    , Space
+    , Strong [ Str "Flipped" , Space , Str "Classroom" ]
+    , Str ":"
+    , Space
+    , Str "Sitzungen"
+    , Space
+    , Str "per"
+    , Space
+    , Str "Zoom"
+    , Space
+    , Str "("
+    , Strong
+        [ Str "Zugangsdaten"
+        , Space
+        , Str "siehe"
+        , Space
+        , Str "[ILIAS]"
+        ]
+    , Str ")"
+    ]
+, RawBlock
+    (Format "markdown") "<div style=\"text-align:center;\">"
+, RawBlock
+    (Format "markdown") "{{% badge style=\"primary\" %}}"
+, Para
+    [ Str "A"
+    , Space
+    , Strong [ Str "simple" ]
+    , Space
+    , Str "text"
+    , Space
+    , Str "to"
+    , Space
+    , Str "be"
+    , Space
+    , Emph [ Str "centred" ]
+    , Space
+    , Str "and"
+    , Space
+    , RawInline (Format "markdown") "<span class='alert'>"
+    , Str "accentuated"
+    , RawInline (Format "markdown") "</span>"
+    ]
+, RawBlock (Format "markdown") "{{% /badge %}}"
+, RawBlock (Format "markdown") "</div>"
+, Para
+    [ Str "Durchf\252hrung"
+    , Space
+    , Str "als"
+    , Space
+    , Strong [ Str "Flipped" , Space , Str "Classroom" ]
+    , Str ":"
+    , Space
+    , Str "Sitzungen"
+    , Space
+    , Str "per"
+    , Space
+    , Str "Zoom"
+    , Space
+    , Str "("
+    , Strong
+        [ Str "Zugangsdaten"
+        , Space
+        , Str "siehe"
+        , Space
+        , Str "[Moodle]"
+        ]
+    , Str ")"
+    ]
+]


### PR DESCRIPTION
We've been using a `button` shortcode as substitute for our `cbox` div/environment. However, those buttons suggest users to be interactive, which is not the case here. So let's switch to non-interactive `badge` shortcodes now.