### PR TITLE
Filter: allow a 'title' key/value pair in 'showme' div (hugo)

### DIFF
--- a/filters/hugo.lua
+++ b/filters/hugo.lua
@@ -80,8 +80,9 @@ end
 function Div(el)
     -- Replace "showme" Div with "expand" Shortcode
     if el.classes[1] == "showme" then
+        local title = el.attributes["title"] and el.attributes["title"] or "Show Me"
         return
-            { pandoc.RawBlock("markdown", '{{% expand "Show Me" %}}') } ..
+            { pandoc.RawBlock("markdown", '{{% expand title="' .. title .. '" %}}') } ..
             el.content ..
             { pandoc.RawBlock("markdown", "{{% /expand %}}") }
     end

--- a/filters/test/Makefile
+++ b/filters/test/Makefile
@@ -2,7 +2,7 @@ DIFF ?= diff --strip-trailing-cr -u
 PANDOC ?= pandoc
 
 
-test: test_rewritelinks test_makedeps test_includemd test_tabs test_code test_bsp test_cbox
+test: test_rewritelinks test_makedeps test_includemd test_tabs test_code test_bsp test_cbox test_showme
 
 test_rewritelinks: readme.md   expected_rewritelinks1.native expected_rewritelinks2.native expected_rewritelinks3.native expected_rewritelinks4.native expected_rewritelinks5.native
 	@$(PANDOC) -L ../hugo_rewritelinks.lua -t native readme.md                                         \
@@ -63,6 +63,10 @@ test_bsp: bsp_span.md   expected_bsp_span.native
 test_cbox: cbox_div.md   expected_cbox_div.native
 	@$(PANDOC) -L ../hugo.lua -t native cbox_div.md                                                    \
 	    | $(DIFF) expected_cbox_div.native -
+
+test_showme: showme_div.md   expected_showme_div.native
+	@$(PANDOC) -L ../hugo.lua -t native showme_div.md                                                    \
+	    | $(DIFF) expected_showme_div.native -
 
 
 expected: expected_rewritelinks1.native expected_rewritelinks2.native expected_rewritelinks3.native expected_rewritelinks4.native expected_rewritelinks5.native
@@ -125,6 +129,10 @@ expected: expected_cbox_div.native
 expected_cbox_div.native: cbox_div.md
 	$(PANDOC) -L ../hugo.lua -t native -o $@ $^
 
+expected: expected_showme_div.native
+expected_showme_div.native: showme_div.md
+	$(PANDOC) -L ../hugo.lua -t native -o $@ $^
+
 
 clean:
 	rm -rf expected_rewritelinks1.native expected_rewritelinks2.native expected_rewritelinks3.native expected_rewritelinks4.native expected_rewritelinks5.native
@@ -134,5 +142,6 @@ clean:
 	rm -rf expected_codeblocks.native
 	rm -rf expected_bsp_span.native
 	rm -rf expected_cbox_div.native
+	rm -rf expected_showme_div.native
 
-.PHONY: test test_rewritelinks test_makedeps test_includemd test_tabs test_code test_bsp test_cbox expected clean
+.PHONY: test test_rewritelinks test_makedeps test_includemd test_tabs test_code test_bsp test_cbox test_showme expected clean

--- a/filters/test/expected_showme_div.native
+++ b/filters/test/expected_showme_div.native
@@ -1,0 +1,135 @@
+[ Header 2 ( "vorlesung" , [] , [] ) [ Str "Vorlesung" ]
+, RawBlock
+    (Format "markdown") "{{% expand title=\"Show Me\" %}}"
+, Para
+    [ Str "A"
+    , Space
+    , Str "simple"
+    , Space
+    , Str "text"
+    , Space
+    , Str "to"
+    , Space
+    , Str "be"
+    , Space
+    , Str "centred"
+    , Space
+    , Str "and"
+    , Space
+    , Str "accentuated"
+    ]
+, RawBlock (Format "markdown") "{{% /expand %}}"
+, RawBlock
+    (Format "markdown")
+    "{{% expand title=\"Hello **World**\" %}}"
+, Para
+    [ Str "A"
+    , Space
+    , Str "simple"
+    , Space
+    , Str "text"
+    , Space
+    , Str "to"
+    , Space
+    , Str "be"
+    , Space
+    , Str "centred"
+    , Space
+    , Str "and"
+    , Space
+    , Str "accentuated"
+    ]
+, RawBlock (Format "markdown") "{{% /expand %}}"
+, Para
+    [ Str "Durchf\252hrung"
+    , Space
+    , Str "als"
+    , Space
+    , Strong [ Str "Flipped" , Space , Str "Classroom" ]
+    , Str ":"
+    , Space
+    , Str "Sitzungen"
+    , Space
+    , Str "per"
+    , Space
+    , Str "Zoom"
+    , Space
+    , Str "("
+    , Strong
+        [ Str "Zugangsdaten"
+        , Space
+        , Str "siehe"
+        , Space
+        , Str "[ILIAS]"
+        ]
+    , Str ")"
+    ]
+, RawBlock
+    (Format "markdown") "{{% expand title=\"Show Me\" %}}"
+, Para
+    [ Str "A"
+    , Space
+    , Strong [ Str "simple" ]
+    , Space
+    , Str "text"
+    , Space
+    , Str "to"
+    , Space
+    , Str "be"
+    , Space
+    , Emph [ Str "centred" ]
+    , Space
+    , Str "and"
+    , Space
+    , RawInline (Format "markdown") "<span class='alert'>"
+    , Str "accentuated"
+    , RawInline (Format "markdown") "</span>"
+    ]
+, RawBlock (Format "markdown") "{{% /expand %}}"
+, Para
+    [ Str "Durchf\252hrung"
+    , Space
+    , Str "als"
+    , Space
+    , Strong [ Str "Flipped" , Space , Str "Classroom" ]
+    , Str ":"
+    , Space
+    , Str "Sitzungen"
+    , Space
+    , Str "per"
+    , Space
+    , Str "Zoom"
+    , Space
+    , Str "("
+    , Strong
+        [ Str "Zugangsdaten"
+        , Space
+        , Str "siehe"
+        , Space
+        , Str "[Moodle]"
+        ]
+    , Str ")"
+    ]
+, RawBlock
+    (Format "markdown") "{{% expand title=\"_Foo_ **Bar**\" %}}"
+, Para
+    [ Str "A"
+    , Space
+    , Strong [ Str "simple" ]
+    , Space
+    , Str "text"
+    , Space
+    , Str "to"
+    , Space
+    , Str "be"
+    , Space
+    , Emph [ Str "centred" ]
+    , Space
+    , Str "and"
+    , Space
+    , RawInline (Format "markdown") "<span class='alert'>"
+    , Str "accentuated"
+    , RawInline (Format "markdown") "</span>"
+    ]
+, RawBlock (Format "markdown") "{{% /expand %}}"
+]

--- a/filters/test/showme_div.md
+++ b/filters/test/showme_div.md
@@ -1,0 +1,21 @@
+## Vorlesung
+
+::: showme
+A simple text to be centred and accentuated
+:::
+
+::: {.showme title="Hello **World**"}
+A simple text to be centred and accentuated
+:::
+
+Durchführung als **Flipped Classroom**: Sitzungen per Zoom (**Zugangsdaten siehe [ILIAS]**)
+
+::: showme
+A **simple** text to be _centred_ and [accentuated]{.alert}
+:::
+
+Durchführung als **Flipped Classroom**: Sitzungen per Zoom (**Zugangsdaten siehe [Moodle]**)
+
+::: {.showme title="_Foo_ **Bar**"}
+A **simple** text to be _centred_ and [accentuated]{.alert}
+:::


### PR DESCRIPTION
previously: 

``` markdown
::: showme
A simple text to be centred and accentuated
:::
```

now also allowed:

``` markdown
::: {.showme title="Hello **World**"}
A simple text to be centred and accentuated
:::
```