### PR TITLE
Examples: fix hugo-lecture author.name parameter

### DIFF
--- a/examples/hugo-lecture/hugo_conf.yaml
+++ b/examples/hugo-lecture/hugo_conf.yaml
@@ -16,7 +16,8 @@ theme:
 #publishDir: "docs"  ## set via Makefile: $(WEB_OUTPUT_DIR)
 
 params:
-  author: "cagix"
+  author:
+    name: "cagix"
   titleSeparator: " "
   alwaysopen: false
   showVisitedLinks: true


### PR DESCRIPTION
Generating the hugo-website example will fail when  `params.author` is used instead of `params.author.name`. See here:

https://mcshelby.github.io/hugo-theme-relearn/basics/migration/#5230