### PR TITLE
relearn: bump version to v5.24.1 (#233)

### DIFF
--- a/docker/install-relearn.sh
+++ b/docker/install-relearn.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 ## Versions
-export RELEARN="5.23.2"
+export RELEARN="5.24.0"
 # set XDG_DATA_HOME externally
 
 ## Hugo Relearn Theme: https://github.com/McShelby/hugo-theme-relearn/releases/latest/

--- a/docker/install-relearn.sh
+++ b/docker/install-relearn.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 ## Versions
-export RELEARN="5.24.0"
+export RELEARN="5.24.1"
 # set XDG_DATA_HOME externally
 
 ## Hugo Relearn Theme: https://github.com/McShelby/hugo-theme-relearn/releases/latest/


### PR DESCRIPTION
waiting because of https://github.com/McShelby/hugo-theme-relearn/issues/773: **need to replace `menuTitle` with `linkTitle` in all documents** before pushing this update 