### PR TITLE
Hugo: replace 'menuTitle' w/ 'linkTitle'

### DIFF
--- a/examples/hugo-lecture/subdir/leaf/readme.md
+++ b/examples/hugo-lecture/subdir/leaf/readme.md
@@ -1,7 +1,7 @@
 ---
 archetype: "chapter"
 title: "Thema SubDir/Leaf"
-menuTitle: "SubDir/Leaf"
+linkTitle: "SubDir/Leaf"
 ---
 
 

--- a/examples/hugo-lecture/subdir/readme.md
+++ b/examples/hugo-lecture/subdir/readme.md
@@ -1,7 +1,7 @@
 ---
 archetype: "chapter"
 title: "Thema SubDir"
-menuTitle: "SubDir"
+linkTitle: "SubDir"
 ---
 
 

--- a/hugo/hugo-lecture/archetypes/chapter.md
+++ b/hugo/hugo-lecture/archetypes/chapter.md
@@ -1,7 +1,7 @@
 ---
 archetype: default
 title: "{{ replace .Name '-' ' ' | title }}"
-menuTitle: "{{ replace .Name '-' ' ' | title }}"
+linkTitle: "{{ replace .Name '-' ' ' | title }}"
 weight: 5
 #hidden: true
 ---

--- a/hugo/hugo-lecture/archetypes/lecture-bc.md
+++ b/hugo/hugo-lecture/archetypes/lecture-bc.md
@@ -1,7 +1,7 @@
 ---
 archetype: lecture-bc
 title: "{{ replace .Name '-' ' ' | title }}"
-menuTitle: "{{ replace .Name '-' ' ' | title }}"
+linkTitle: "{{ replace .Name '-' ' ' | title }}"
 author: "BC George (HSBI)"
 weight: 5
 readings:

--- a/hugo/hugo-lecture/archetypes/lecture-cg.md
+++ b/hugo/hugo-lecture/archetypes/lecture-cg.md
@@ -1,7 +1,7 @@
 ---
 archetype: lecture-cg
 title: "{{ replace .Name '-' ' ' | title }}"
-menuTitle: "{{ replace .Name '-' ' ' | title }}"
+linkTitle: "{{ replace .Name '-' ' ' | title }}"
 author: "Carsten Gips (HSBI)"
 weight: 5
 readings:

--- a/hugo/hugo-lecture/archetypes/lecture-cy.md
+++ b/hugo/hugo-lecture/archetypes/lecture-cy.md
@@ -1,7 +1,7 @@
 ---
 archetype: lecture-cy
 title: "{{ replace .Name '-' ' ' | title }}"
-menuTitle: "{{ replace .Name '-' ' ' | title }}"
+linkTitle: "{{ replace .Name '-' ' ' | title }}"
 author: "Canan Yıldız (Türkisch-Deutsche Universität)"
 weight: 5
 readings:

--- a/hugo/hugo-lecture/layouts/shortcodes/schedule.html
+++ b/hugo/hugo-lecture/layouts/shortcodes/schedule.html
@@ -42,7 +42,7 @@
                         {{ $path := .File.Dir | path.Clean }}
                         {{ $path = replace ($path | path.Clean) "/" " > " | upper }}
                         {{if gt (len $path) 1}}{{ printf "%s > " $path }}{{end}}
-                        {{ $title := .Params.menutitle | default .Title }}
+                        {{ $title := .Params.linkTitle | default .Title }}
                         <a href="{{- .Permalink | safeURL -}}"><strong>{{- $title -}}</strong></a>
                         {{ if $leader }}{{ printf " (%s)" $leader }}{{ end }}
                         {{ if $notes }}<br><em>{{ printf "Hinweis: %s" $notes }}</em>{{ end }}
@@ -64,7 +64,7 @@
                 {{ if $topic }}
                     {{ with $.Site.GetPage $topic }}
                     <li>
-                        {{ $title := .Params.menutitle | default .Title }}
+                        {{ $title := .Params.linkTitle | default .Title }}
                         <a href="{{- .Permalink | safeURL -}}"><strong>{{- $title -}}</strong></a>
                         {{ if $due }}<br>{{ printf "(%s)" $due }}{{ end }}
                     </li>


### PR DESCRIPTION
this should prepare us for Relearn 5.24.0 - `menuTitle` being deprecated

(see https://github.com/McShelby/hugo-theme-relearn/issues/714)