### PR TITLE
hugo: REVERT version back to v0.122.0

### DIFF
--- a/docker/install-hugo.sh
+++ b/docker/install-hugo.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 ## Versions
-export HUGO="0.124.0"
+export HUGO="0.122.0"
 # set ARCH="amd64" or ARCH="arm64" externally
 export ARCH="${ARCH:-amd64}"  # if not set, use 'amd64' as default
 


### PR DESCRIPTION
v0.123 startet to handle the baseURL wrong - local images won't be resolved properly

see https://github.com/McShelby/hugo-theme-relearn/issues/805